### PR TITLE
Implement Eq, PartialEq for Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display};
 
 /// This type represents all possible errors that can occur when serializing or deserializing
 /// DynamoDB data.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Error(ErrorImpl);
 
 impl Display for Error {
@@ -26,7 +26,7 @@ impl de::Error for Error {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ErrorImpl {
     /// Serde error
     Message(String),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -85,3 +85,18 @@ fn subsequent_flattened() {
         }),
     });
 }
+
+#[test]
+fn error_eq() {
+    use super::{Error, ErrorImpl};
+
+    assert_eq!(
+        Into::<Error>::into(ErrorImpl::Message(String::from("one"))),
+        Into::<Error>::into(ErrorImpl::Message(String::from("one"))),
+    );
+
+    assert_ne!(
+        Into::<Error>::into(ErrorImpl::Message(String::from("one"))),
+        Into::<Error>::into(ErrorImpl::Message(String::from("two"))),
+    );
+}


### PR DESCRIPTION
I was working with this crate, and as a part of what I was doing I needed to build out my own custom error type where one of its enum values took a `serde_dynamo::Error`, like:

```rust
enum DynamoError {
    SerdeDynamo(serde_dynamo::Error),
    Other,
    ...
}
```

The later, in my tests, I wanted to check that the error I was getting back from one of my functions was the expected `DynamoError` error, like this:

```rust
assert_eq!(result.err().unwrap(), DynamoErr::Other);
```

But to do that, I had to have `enum DynamoError` derive at least `PartialEq`, of course. Otherwise, I get this:

```text
error[E0369]: binary operation `==` cannot be applied to type `$crate::error::DynamoError`
```

But trying to derive those traits on `DynamoError` doesn't work because `serde_dynamo::Error` doesn't implement at least `PartialEq`.

```text
error[E0369]: binary operation `==` cannot be applied to type `serde_dynamo::Error`
  --> src/[snip]/error.rs:12:17
   |
12 |     SerdeDynamo(serde_dynamo::Error),
   |                 ^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0369]: binary operation `!=` cannot be applied to type `serde_dynamo::Error`
  --> src/[snip]/error.rs:12:17
   |
12 |     SerdeDynamo(serde_dynamo::Error),
   |                 ^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to 2 previous errors; 1 warning emitted
```

This PR fixes that. Also, it seems that error types commonly implement `PartialEq` (if not also `Eq`), so this brings `serde_dynamo::Error` in line with that.