### PR TITLE
"Unreachable" MapKeySerializer functions that are actually reachable

### DIFF
--- a/src/de/deserializer_enum.rs
+++ b/src/de/deserializer_enum.rs
@@ -48,9 +48,7 @@ impl<'de, 'a> VariantAccess<'de> for DeserializerVariant {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {
-        // If the `Visitor` expected this variant to be a unit variant, the input should have been
-        // the plain string case handled in `deserialize_enum`.
-        unreachable!()
+        Ok(())
     }
 
     fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>

--- a/src/de/deserializer_map.rs
+++ b/src/de/deserializer_map.rs
@@ -121,6 +121,17 @@ impl<'de> de::Deserializer<'de> for DeserializerMapKey {
         de.deserialize_enum(name, variants, visitor)
     }
 
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
     deserialize_integer_key!(deserialize_i8   => visit_i8);
     deserialize_integer_key!(deserialize_i16  => visit_i16);
     deserialize_integer_key!(deserialize_i32  => visit_i32);

--- a/src/de/deserializer_map.rs
+++ b/src/de/deserializer_map.rs
@@ -1,6 +1,8 @@
 use super::{AttributeValue, Deserializer, Error, ErrorImpl, Item, Result};
-use serde::de::{self, DeserializeSeed, MapAccess, Visitor};
-use serde::forward_to_deserialize_any;
+use serde::{
+    de::{self, DeserializeSeed, MapAccess, Visitor},
+    forward_to_deserialize_any, serde_if_integer128,
+};
 
 pub struct DeserializerMap<'a> {
     drain: std::collections::hash_map::Drain<'a, String, AttributeValue>,
@@ -136,12 +138,16 @@ impl<'de> de::Deserializer<'de> for DeserializerMapKey {
     deserialize_integer_key!(deserialize_i16  => visit_i16);
     deserialize_integer_key!(deserialize_i32  => visit_i32);
     deserialize_integer_key!(deserialize_i64  => visit_i64);
-    deserialize_integer_key!(deserialize_i128 => visit_i128);
+    serde_if_integer128! {
+        deserialize_integer_key!(deserialize_i128 => visit_i128);
+    }
     deserialize_integer_key!(deserialize_u8   => visit_u8);
     deserialize_integer_key!(deserialize_u16  => visit_u16);
     deserialize_integer_key!(deserialize_u32  => visit_u32);
     deserialize_integer_key!(deserialize_u64  => visit_u64);
-    deserialize_integer_key!(deserialize_u128 => visit_u128);
+    serde_if_integer128! {
+        deserialize_integer_key!(deserialize_u128 => visit_u128);
+    }
 
     forward_to_deserialize_any! {
         bool f32 f64 char bytes byte_buf option unit

--- a/src/de/deserializer_map.rs
+++ b/src/de/deserializer_map.rs
@@ -55,7 +55,7 @@ impl DeserializerMapKey {
     }
 }
 
-impl<'de, 'a> de::Deserializer<'de> for DeserializerMapKey {
+impl<'de> de::Deserializer<'de> for DeserializerMapKey {
     type Error = Error;
 
     // Look at the input data to decide what Serde data model type to
@@ -89,8 +89,24 @@ impl<'de, 'a> de::Deserializer<'de> for DeserializerMapKey {
         visitor.visit_string(self.input)
     }
 
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        let de = Deserializer::from_attribute_value(AttributeValue {
+            s: Some(self.input),
+            ..AttributeValue::default()
+        });
+        de.deserialize_enum(name, variants, visitor)
+    }
+
     forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char enum bytes byte_buf option unit
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char bytes byte_buf option unit
         unit_struct newtype_struct seq tuple tuple_struct map struct ignored_any
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,7 +40,7 @@ pub enum ErrorImpl {
     ExpectedMap,
     /// Expected seq
     ExpectedSeq,
-    /// Expected seq
+    /// Expected num
     ExpectedNum,
     /// Expected bool
     ExpectedBool,

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,8 @@ pub enum ErrorImpl {
     FailedToParseInt(String, std::num::ParseIntError),
     /// Failed to parse as a float
     FailedToParseFloat(String, std::num::ParseFloatError),
+    /// Key must be a string
+    KeyMustBeAString,
 }
 
 #[allow(clippy::from_over_into)]
@@ -91,6 +93,7 @@ impl Display for ErrorImpl {
             ErrorImpl::FailedToParseFloat(s, err) => {
                 write!(f, "Failed to parse '{0}' as a float: {1}", s, err)
             }
+            ErrorImpl::KeyMustBeAString => f.write_str("Key must be a string"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,7 @@ pub enum ErrorImpl {
     FailedToParseFloat(String, std::num::ParseFloatError),
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<Error> for ErrorImpl {
     fn into(self) -> Error {
         Error(self)

--- a/src/ser/serializer_map.rs
+++ b/src/ser/serializer_map.rs
@@ -148,9 +148,9 @@ impl<'a> ser::Serializer for MapKeySerializer {
         self,
         _name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
+        variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+        self.serialize_str(variant)
     }
     fn serialize_tuple_struct(
         self,

--- a/src/ser/serializer_map.rs
+++ b/src/ser/serializer_map.rs
@@ -1,5 +1,5 @@
 use super::{AttributeValue, Error, ErrorImpl, Item, Result, Serializer};
-use serde::{ser, Serialize};
+use serde::{ser, serde_if_integer128, Serialize};
 
 pub struct SerializerMap {
     item: Item,
@@ -86,8 +86,10 @@ impl<'a> ser::Serializer for MapKeySerializer {
     fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
         Ok(v.to_string())
     }
-    fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
-        Ok(v.to_string())
+    serde_if_integer128! {
+        fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+            Ok(v.to_string())
+        }
     }
     fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
         Ok(v.to_string())
@@ -98,8 +100,10 @@ impl<'a> ser::Serializer for MapKeySerializer {
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
         Ok(v.to_string())
     }
-    fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
-        Ok(v.to_string())
+    serde_if_integer128! {
+        fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+            Ok(v.to_string())
+        }
     }
     fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
         Err(ErrorImpl::KeyMustBeAString.into())

--- a/src/ser/serializer_map.rs
+++ b/src/ser/serializer_map.rs
@@ -71,35 +71,41 @@ impl<'a> ser::Serializer for MapKeySerializer {
     type SerializeStruct = Self;
     type SerializeStructVariant = Self;
 
-    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
     }
-    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
     }
-    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
     }
-    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
     }
-    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
     }
-    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+    fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
     }
-    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
     }
-    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+    fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
     }
     fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+        Err(ErrorImpl::KeyMustBeAString.into())
     }
     fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+        Err(ErrorImpl::KeyMustBeAString.into())
     }
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
         Ok(v.to_string())
@@ -111,10 +117,10 @@ impl<'a> ser::Serializer for MapKeySerializer {
         unreachable!()
     }
     fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+        Err(ErrorImpl::KeyMustBeAString.into())
     }
-    fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        self.serialize_str(&v.to_string())
     }
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
         Err(ErrorImpl::KeyMustBeAString.into())

--- a/src/ser/serializer_map.rs
+++ b/src/ser/serializer_map.rs
@@ -1,4 +1,4 @@
-use super::{AttributeValue, Error, Item, Result, Serializer};
+use super::{AttributeValue, Error, ErrorImpl, Item, Result, Serializer};
 use serde::{ser, Serialize};
 
 pub struct SerializerMap {
@@ -117,32 +117,32 @@ impl<'a> ser::Serializer for MapKeySerializer {
         unreachable!()
     }
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+        Err(ErrorImpl::KeyMustBeAString.into())
     }
     fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: Serialize,
     {
-        unreachable!()
+        Err(ErrorImpl::KeyMustBeAString.into())
     }
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+        Err(ErrorImpl::KeyMustBeAString.into())
     }
     fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
         unreachable!()
     }
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        unreachable!()
+        Err(ErrorImpl::KeyMustBeAString.into())
     }
     fn serialize_struct(
         self,
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        unreachable!()
+        Err(ErrorImpl::KeyMustBeAString.into())
     }
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
+        Err(ErrorImpl::KeyMustBeAString.into())
     }
     fn serialize_unit_variant(
         self,
@@ -157,7 +157,7 @@ impl<'a> ser::Serializer for MapKeySerializer {
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        unreachable!()
+        Err(ErrorImpl::KeyMustBeAString.into())
     }
     fn serialize_tuple_variant(
         self,
@@ -166,7 +166,7 @@ impl<'a> ser::Serializer for MapKeySerializer {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        unreachable!()
+        Err(ErrorImpl::KeyMustBeAString.into())
     }
     fn serialize_newtype_struct<T: ?Sized>(
         self,
@@ -185,7 +185,7 @@ impl<'a> ser::Serializer for MapKeySerializer {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        unreachable!()
+        Err(ErrorImpl::KeyMustBeAString.into())
     }
     fn serialize_newtype_variant<T: ?Sized>(
         self,
@@ -197,7 +197,7 @@ impl<'a> ser::Serializer for MapKeySerializer {
     where
         T: Serialize,
     {
-        unreachable!()
+        Err(ErrorImpl::KeyMustBeAString.into())
     }
 }
 

--- a/src/ser/serializer_map.rs
+++ b/src/ser/serializer_map.rs
@@ -177,12 +177,12 @@ impl<'a> ser::Serializer for MapKeySerializer {
     fn serialize_newtype_struct<T: ?Sized>(
         self,
         _name: &'static str,
-        _value: &T,
+        value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
         T: Serialize,
     {
-        unreachable!()
+        value.serialize(self)
     }
     fn serialize_struct_variant(
         self,

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -48,7 +48,7 @@ fn serialize_num() {
                 }
             );
         }};
-    };
+    }
 
     serialize_num!(i8, -1);
     serialize_num!(u8, 1);
@@ -438,7 +438,7 @@ fn internally_tagged_enum() {
     enum Enum {
         One { one: u8 },
         Two { one: u8, two: u8 },
-    };
+    }
 
     let result = to_attribute_value(Enum::Two { one: 1, two: 2 }).unwrap();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -466,63 +466,65 @@ mod map_key {
         }
     }
 
-    // TODO: Make this not panic (`unreachable!()`)
-    // #[test]
-    // fn i8() {
-    //     map_key_round_trip(5_i8, Ok("5"));
-    // }
+    #[test]
+    fn i8() {
+        map_key_round_trip(5_i8, Ok("5"));
+    }
 
-    // TODO: Make this not panic (`unreachable!()`)
-    // #[test]
-    // fn u8() {
-    //     map_key_round_trip(5_u8, Ok("5"));
-    // }
+    #[test]
+    fn u8() {
+        map_key_round_trip(5_u8, Ok("5"));
+    }
 
-    // TODO: Make this not panic (`unreachable!()`)
-    // #[test]
-    // fn i16() {
-    //     map_key_round_trip(5_i16, Ok("5"));
-    // }
+    #[test]
+    fn i16() {
+        map_key_round_trip(5_i16, Ok("5"));
+    }
 
-    // TODO: Make this not panic (`unreachable!()`)
-    // #[test]
-    // fn u16() {
-    //     map_key_round_trip(5_u16, Ok("5"));
-    // }
+    #[test]
+    fn u16() {
+        map_key_round_trip(5_u16, Ok("5"));
+    }
 
-    // TODO: Make this not panic (`unreachable!()`)
-    // #[test]
-    // fn i32() {
-    //     map_key_round_trip(5_i32, Ok("5"));
-    // }
+    #[test]
+    fn i32() {
+        map_key_round_trip(5_i32, Ok("5"));
+    }
 
-    // TODO: Make this not panic (`unreachable!()`)
-    // #[test]
-    // fn u32() {
-    //     map_key_round_trip(5_u32, Ok("5"));
-    // }
+    #[test]
+    fn u32() {
+        map_key_round_trip(5_u32, Ok("5"));
+    }
 
-    // TODO: Make this not panic (`unreachable!()`)
-    // #[test]
-    // fn i64() {
-    //     map_key_round_trip(5_i64, Ok("5"));
-    // }
+    #[test]
+    fn i64() {
+        map_key_round_trip(5_i64, Ok("5"));
+    }
 
-    // TODO: Make this not panic (`unreachable!()`)
-    // #[test]
-    // fn u64() {
-    //     map_key_round_trip(5_u64, Ok("5"));
-    // }
+    #[test]
+    fn u64() {
+        map_key_round_trip(5_u64, Ok("5"));
+    }
 
-    // #[test]
-    // fn bool() {
-    //     map_key_round_trip(true, key_must_be_a_string());
-    // }
+    #[test]
+    fn i128() {
+        map_key_round_trip(5_i128, Ok("5"));
+    }
 
-    // #[test]
-    // fn char() {
-    //     map_key_round_trip('a', Ok("a"));
-    // }
+    #[test]
+    fn u128() {
+        map_key_round_trip(5_u128, Ok("5"));
+    }
+
+    #[test]
+    fn bool() {
+        map_key_round_trip(true, key_must_be_a_string());
+    }
+
+    #[test]
+    fn char() {
+        map_key_round_trip('a', Ok("a"));
+    }
 
     #[test]
     fn none() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -168,3 +168,408 @@ mod from_items {
         assert_eq!(Into::<Error>::into(ErrorImpl::ExpectedSeq), err);
     }
 }
+
+// Tests for various types being used as map keys
+#[cfg(test)]
+mod map_key {
+    use std::{fmt::Debug, hash::Hash};
+
+    use maplit::hashmap;
+    use serde::de::DeserializeOwned;
+    use serde::{Deserialize, Serialize};
+
+    use crate::{error::ErrorImpl, from_attribute_value, to_attribute_value, Result};
+
+    /// The provided `key` value is used as a map key that gets serialized, then deserialized.
+    /// The provided `Result` indicates whether serializing should be able to be successful or not.
+    /// If serializing is expected to be successful, then deserialization is also expected to be.
+    ///
+    /// Success/failure of serialization is compared with serialization of the map key with
+    /// `serde_json`, as well. If `serde_json` is able to serialize the map key, then it's expected
+    /// that this crate should, as well.
+    ///
+    /// An `Ok(&str)` value is compared against a successful serialization, and the result of
+    /// deserialization is compared against the original value provided in `key`.
+    ///
+    /// An `Err(E)` value is compared against the error returned a serialization failure.
+    ///
+    /// If `Ok(&str)` is provided and there is an error, this panics.
+    ///
+    /// If `Err(E)` is provided and there is no error, this panics.
+    fn map_key_round_trip<K>(key: K, expect_serialized_key: Result<&str>)
+    where
+        K: Debug + Clone + Eq + Hash + Serialize + DeserializeOwned,
+    {
+        let original = hashmap! { key => String::from("value") };
+
+        let original_as_json = match serde_json::to_string(&original) {
+            Ok(original_as_json) => {
+                if expect_serialized_key.is_err() {
+                    panic!(
+                        "Expecting to get an error serializing {:?} to AttributeValue, \
+                        but it was able to be serialized to JSON: {}",
+                        original, original_as_json
+                    );
+                }
+
+                original_as_json
+            }
+            Err(err) => {
+                if expect_serialized_key.is_ok() {
+                    panic!(
+                        "Expecting to be able to serialize {:?} to AttributeValue, \
+                        but it could not be serialized to JSON: {}",
+                        original, err,
+                    );
+                }
+
+                format!("unsupported by serde_json: {}", err)
+            }
+        };
+
+        println!("{:?} as JSON: {}", original, original_as_json);
+
+        let actual_serialized = to_attribute_value(original.clone());
+
+        let (expected_serialized_key, actual_serialized) = match expect_serialized_key {
+            Ok(expected_serialized) => (
+                expected_serialized,
+                actual_serialized.unwrap_or_else(|err| {
+                    panic!(
+                        "Failed to serialize to AttributeValue: {}\n\n\
+                    The JSON representation would be:\n{}\n",
+                        err, original_as_json,
+                    )
+                }),
+            ),
+            Err(expected_err) => {
+                assert_eq!(
+                    expected_err,
+                    actual_serialized.expect_err("Expected an error when serializing"),
+                    "Did not get the expected error when serializing"
+                );
+                return;
+            }
+        };
+
+        let expected_serialized = to_attribute_value(hashmap! {
+            expected_serialized_key => "value",
+        })
+        .expect("Failed to serialize expected value");
+        assert_eq!(
+            expected_serialized, actual_serialized,
+            "Serialized value is not what was expected"
+        );
+
+        let deserialized = from_attribute_value(actual_serialized.clone()).unwrap_or_else(|err| {
+            panic!(
+                "Failed to deserialize: {}\nThe serialized value was:\n{:#?}\n",
+                err, actual_serialized
+            )
+        });
+        assert_eq!(
+            original, deserialized,
+            "Deserialized value is not what was expected"
+        );
+    }
+
+    fn key_must_be_a_string<T>() -> Result<T> {
+        Err(ErrorImpl::KeyMustBeAString.into())
+    }
+
+    // Tests using different types of enum variants as map keys.
+    // See: https://serde.rs/enum-representations.html
+    mod enum_variant {
+        use super::*;
+
+        // https://serde.rs/enum-representations.html#externally-tagged
+        mod externally_tagged {
+            use super::*;
+
+            #[derive(
+                Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+            )]
+            enum VariantType {
+                Unit,
+                Newtype(String),
+                Struct { value: String },
+                Tuple(String, String),
+            }
+
+            #[test]
+            fn unit_variant() {
+                // TODO: Fix this. It currently panics (`unreachable!()`) in serde_dynamo,
+                //       but works in serde_json. Making it round-trip properly in serde_dynamo
+                //       is more complicated.
+                // map_key_round_trip(VariantType::Unit, Ok("Unit"));
+            }
+
+            #[test]
+            fn newtype_variant() {
+                map_key_round_trip(
+                    VariantType::Newtype(String::from("newtype")),
+                    key_must_be_a_string(),
+                );
+            }
+
+            #[test]
+            fn struct_variant() {
+                map_key_round_trip(
+                    VariantType::Struct {
+                        value: String::from("STRUCT VALUE"),
+                    },
+                    key_must_be_a_string(),
+                );
+            }
+
+            #[test]
+            fn tuple_struct() {
+                map_key_round_trip(
+                    VariantType::Tuple(String::from("TUPLE.0"), String::from("TUPLE.1")),
+                    key_must_be_a_string(),
+                );
+            }
+        }
+
+        // https://serde.rs/enum-representations.html#internally-tagged
+        mod internally_tagged {
+            use super::*;
+
+            #[derive(
+                Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+            )]
+            #[serde(tag = "type")]
+            enum VariantType {
+                Unit,
+                Newtype(String),
+                Struct { value: String },
+                // Tuple(String, String), // serde causes a compile error for this one.
+            }
+
+            #[test]
+            fn unit_variant() {
+                map_key_round_trip(VariantType::Unit, key_must_be_a_string());
+            }
+
+            #[test]
+            fn newtype_variant() {
+                map_key_round_trip(
+                    VariantType::Newtype(String::from("newtype")),
+                    Err(<ErrorImpl as serde::ser::Error>::custom(
+                        "cannot serialize tagged newtype variant VariantType::Newtype containing a string"
+                    ).into()),
+                );
+            }
+
+            #[test]
+            fn struct_variant() {
+                map_key_round_trip(
+                    VariantType::Struct {
+                        value: String::from("STRUCT VALUE"),
+                    },
+                    key_must_be_a_string(),
+                );
+            }
+        }
+
+        // https://serde.rs/enum-representations.html#adjacently-tagged
+        mod adjacently_tagged {
+            use super::*;
+
+            #[derive(
+                Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+            )]
+            #[serde(tag = "type", content = "content")]
+            enum VariantType {
+                Unit,
+                Newtype(String),
+                Struct { value: String },
+                Tuple(String, String),
+            }
+
+            #[test]
+            fn unit_variant() {
+                map_key_round_trip(VariantType::Unit, key_must_be_a_string());
+            }
+
+            #[test]
+            fn newtype_variant() {
+                map_key_round_trip(
+                    VariantType::Newtype(String::from("newtype")),
+                    key_must_be_a_string(),
+                );
+            }
+
+            #[test]
+            fn struct_variant() {
+                map_key_round_trip(
+                    VariantType::Struct {
+                        value: String::from("STRUCT VALUE"),
+                    },
+                    key_must_be_a_string(),
+                );
+            }
+
+            #[test]
+            fn tuple_struct() {
+                map_key_round_trip(
+                    VariantType::Tuple(String::from("TUPLE.0"), String::from("TUPLE.1")),
+                    key_must_be_a_string(),
+                );
+            }
+        }
+
+        // https://serde.rs/enum-representations.html#untagged
+        mod untagged {
+            use super::*;
+
+            #[derive(
+                Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+            )]
+            #[serde(untagged)]
+            enum VariantType {
+                Unit,
+                Newtype(String),
+                Struct { value: String },
+                Tuple(String, String),
+            }
+
+            #[test]
+            fn unit_variant() {
+                map_key_round_trip(VariantType::Unit, key_must_be_a_string());
+            }
+
+            #[test]
+            fn newtype_variant() {
+                map_key_round_trip(VariantType::Newtype(String::from("newtype")), Ok("newtype"));
+            }
+
+            #[test]
+            fn struct_variant() {
+                map_key_round_trip(
+                    VariantType::Struct {
+                        value: String::from("STRUCT VALUE"),
+                    },
+                    key_must_be_a_string(),
+                );
+            }
+
+            #[test]
+            fn tuple_struct() {
+                map_key_round_trip(
+                    VariantType::Tuple(String::from("TUPLE.0"), String::from("TUPLE.1")),
+                    key_must_be_a_string(),
+                );
+            }
+        }
+    }
+
+    // TODO: Make this not panic (`unreachable!()`)
+    // #[test]
+    // fn i8() {
+    //     map_key_round_trip(5_i8, Ok("5"));
+    // }
+
+    // TODO: Make this not panic (`unreachable!()`)
+    // #[test]
+    // fn u8() {
+    //     map_key_round_trip(5_u8, Ok("5"));
+    // }
+
+    // TODO: Make this not panic (`unreachable!()`)
+    // #[test]
+    // fn i16() {
+    //     map_key_round_trip(5_i16, Ok("5"));
+    // }
+
+    // TODO: Make this not panic (`unreachable!()`)
+    // #[test]
+    // fn u16() {
+    //     map_key_round_trip(5_u16, Ok("5"));
+    // }
+
+    // TODO: Make this not panic (`unreachable!()`)
+    // #[test]
+    // fn i32() {
+    //     map_key_round_trip(5_i32, Ok("5"));
+    // }
+
+    // TODO: Make this not panic (`unreachable!()`)
+    // #[test]
+    // fn u32() {
+    //     map_key_round_trip(5_u32, Ok("5"));
+    // }
+
+    // TODO: Make this not panic (`unreachable!()`)
+    // #[test]
+    // fn i64() {
+    //     map_key_round_trip(5_i64, Ok("5"));
+    // }
+
+    // TODO: Make this not panic (`unreachable!()`)
+    // #[test]
+    // fn u64() {
+    //     map_key_round_trip(5_u64, Ok("5"));
+    // }
+
+    // #[test]
+    // fn bool() {
+    //     map_key_round_trip(true, key_must_be_a_string());
+    // }
+
+    // #[test]
+    // fn char() {
+    //     map_key_round_trip('a', Ok("a"));
+    // }
+
+    #[test]
+    fn none() {
+        map_key_round_trip(Option::<()>::None, key_must_be_a_string());
+    }
+
+    #[test]
+    fn some() {
+        map_key_round_trip(Some(String::from("a")), key_must_be_a_string());
+    }
+
+    #[test]
+    fn tuple() {
+        map_key_round_trip((), key_must_be_a_string());
+    }
+
+    #[test]
+    fn struct_() {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        struct Struct {}
+
+        map_key_round_trip(Struct {}, key_must_be_a_string());
+    }
+
+    #[test]
+    fn unit_struct() {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        struct Struct;
+
+        map_key_round_trip(Struct {}, key_must_be_a_string());
+    }
+
+    #[test]
+    fn tuple_struct() {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        struct Struct(String, String);
+
+        map_key_round_trip(
+            Struct(String::from("a"), String::from("b")),
+            key_must_be_a_string(),
+        );
+    }
+
+    // TODO: Make this not panic (`unreachable!()`)
+    // #[test]
+    // fn newtype_struct() {
+    //     #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    //     struct Struct(i64);
+
+    //     map_key_round_trip(Struct(5), Ok("5"));
+    // }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,7 +17,7 @@ fn internally_tagged_enum() {
     enum Subject {
         One { one: u8 },
         Two { two: u8 },
-    };
+    }
 
     round_trip(Subject::One { one: 1 });
     round_trip(Subject::Two { two: 2 });
@@ -30,7 +30,7 @@ fn adjacently_tagged_enum() {
     enum Subject {
         One { one: u8 },
         Two { two: u8 },
-    };
+    }
 
     round_trip(Subject::One { one: 1 });
     round_trip(Subject::Two { two: 2 });
@@ -43,7 +43,7 @@ fn untagged_enum() {
     enum Simple {
         One { one: u8 },
         Two { two: u8 },
-    };
+    }
 
     round_trip(Simple::One { one: 1 });
     round_trip(Simple::Two { two: 2 });
@@ -53,7 +53,7 @@ fn untagged_enum() {
     enum Overlapping {
         Two { one: u8, two: u8 },
         Three { one: u8, three: u8 },
-    };
+    }
 
     round_trip(Overlapping::Two { one: 1, two: 2 });
     round_trip(Overlapping::Three { one: 1, three: 3 });

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -261,6 +261,11 @@ mod map_key {
             "Serialized value is not what was expected"
         );
 
+        println!(
+            "{} as dynamo item: {:?}",
+            original_as_json, expected_serialized
+        );
+
         let deserialized = from_attribute_value(actual_serialized.clone()).unwrap_or_else(|err| {
             panic!(
                 "Failed to deserialize: {}\nThe serialized value was:\n{:#?}\n",
@@ -298,10 +303,7 @@ mod map_key {
 
             #[test]
             fn unit_variant() {
-                // TODO: Fix this. It currently panics (`unreachable!()`) in serde_dynamo,
-                //       but works in serde_json. Making it round-trip properly in serde_dynamo
-                //       is more complicated.
-                // map_key_round_trip(VariantType::Unit, Ok("Unit"));
+                map_key_round_trip(VariantType::Unit, Ok("Unit"));
             }
 
             #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -174,7 +174,7 @@ mod from_items {
 mod map_key {
     use std::{fmt::Debug, hash::Hash};
 
-    use maplit::hashmap;
+    use maplit::{btreemap, hashmap};
     use serde::de::DeserializeOwned;
     use serde::{Deserialize, Serialize};
 
@@ -198,9 +198,9 @@ mod map_key {
     /// If `Err(E)` is provided and there is no error, this panics.
     fn map_key_round_trip<K>(key: K, expect_serialized_key: Result<&str>)
     where
-        K: Debug + Clone + Eq + Hash + Serialize + DeserializeOwned,
+        K: Debug + Clone + Ord + Serialize + DeserializeOwned,
     {
-        let original = hashmap! { key => String::from("value") };
+        let original = btreemap! { key => String::from("value") };
 
         let original_as_json = match serde_json::to_string(&original) {
             Ok(original_as_json) => {
@@ -543,7 +543,7 @@ mod map_key {
 
     #[test]
     fn struct_() {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
         struct Struct {}
 
         map_key_round_trip(Struct {}, key_must_be_a_string());
@@ -551,7 +551,7 @@ mod map_key {
 
     #[test]
     fn unit_struct() {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
         struct Struct;
 
         map_key_round_trip(Struct {}, key_must_be_a_string());
@@ -559,7 +559,7 @@ mod map_key {
 
     #[test]
     fn tuple_struct() {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
         struct Struct(String, String);
 
         map_key_round_trip(
@@ -568,12 +568,11 @@ mod map_key {
         );
     }
 
-    // TODO: Make this not panic (`unreachable!()`)
-    // #[test]
-    // fn newtype_struct() {
-    //     #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-    //     struct Struct(i64);
+    #[test]
+    fn newtype_struct() {
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+        struct Struct(i64);
 
-    //     map_key_round_trip(Struct(5), Ok("5"));
-    // }
+        map_key_round_trip(Struct(5), Ok("5"));
+    }
 }


### PR DESCRIPTION
This is some work on addressing some `unrechable!()` instances that are actually reachable (and therefore panic) when handling map keys.

The goal here is to support enums in the same way `serde_json` does. Things that serialize to map keys with `serde_json` should also serialize to map keys in `serde_dynamo`. The same for things that fail to serialize to maps keys with `serde_json`.

There are some cases where a proper fix is more complicated. I've included those tests and commented them out for easier dev work.

The one of these that's most important to me currently is `map_key::enum_variant::externally_tagged::unit_variant()`, which is the panic I ran into that let me down this rabbit hole. I'm not sure if you know of a quick solution to round-trip that value.