### PR TITLE
Allow newer versions of Rusoto to be used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ repository = "https://github.com/zenlist/serde_dynamo"
 keywords = ["serde", "rusoto", "dynamodb", "dynamo", "serde_dynamodb"]
 
 [dependencies]
-rusoto_dynamodb = { version = "0.47", default-features = false }
+rusoto_dynamodb = { version = "0", default-features = false }
 serde = "1"
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 maplit = "1"
-rusoto_core = { version = "0.47", default-features = false, features = ["rustls"] }
+rusoto_core = { version = "0", default-features = false, features = ["rustls"] }
 serde_bytes = "0.11"
 serde_derive = "1"
 serde_json = "1"


### PR DESCRIPTION
This is to resolve an issue I ran into where I had updated to rusoto 0.47 and was also using this crate (which had 0.46 as a dependency). This is what the error looked like:

```text
error[E0432]: unresolved import `crate::tls`
  --> /[...]/.cargo/registry/src/github.com-1ecc6299db9ec823/rusoto_core-0.46.0/src/request.rs:33:12
   |
33 | use crate::tls::HttpsConnector;
   |            ^^^ could not find `tls` in the crate root

error[E0425]: cannot find value `connector` in this scope
   --> /[...]/.cargo/registry/src/github.com-1ecc6299db9ec823/rusoto_core-0.46.0/src/request.rs:229:33
    |
229 |         Ok(Self::from_connector(connector))
    |                                 ^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `connector` in this scope
   --> /[...]/.cargo/registry/src/github.com-1ecc6299db9ec823/rusoto_core-0.46.0/src/request.rs:240:45
    |
240 |         Ok(Self::from_connector_with_config(connector, config))
    |                                             ^^^^^^^^^ not found in this scope

error[E0599]: no method named `lock` found for struct `SHARED_CLIENT` in the current scope
  --> /[...]/.cargo/registry/src/github.com-1ecc6299db9ec823/rusoto_core-0.46.0/src/client.rs:29:38
   |
15 | / lazy_static! {
16 | |     static ref SHARED_CLIENT: Mutex<Weak<ClientInner<DefaultCredentialsProvider, HttpClient>>> =
17 | |         Mutex::new(Weak::new());
18 | | }
   | |_- method `lock` not found for this
...
29 |           let mut lock = SHARED_CLIENT.lock().unwrap();
   |                                        ^^^^ method not found in `SHARED_CLIENT`

error: aborting due to 4 previous errors
```