### PR TITLE
Enable feature flags for rusoto & aws_sdk_dynamodb, add doctests for aws_sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ repository = "https://github.com/zenlist/serde_dynamo"
 keywords = ["serde", "rusoto", "dynamodb", "dynamo", "serde_dynamodb"]
 
 [dependencies]
-rusoto_dynamodb = { version = "0.46", default-features = false, optional = true }
+rusoto_dynamodb = { version = "0.47", default-features = false, optional = true }
 aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", optional = true }
 serde = "1"
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 maplit = "1"
-rusoto_core = { version = "0.46", default-features = false, features = ["rustls"] }
+rusoto_core = { version = "0.47", default-features = false, features = ["rustls"] }
 serde_bytes = "0.11"
 serde_derive = "1"
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/zenlist/serde_dynamo"
 keywords = ["serde", "rusoto", "dynamodb", "dynamo", "serde_dynamodb"]
 
 [dependencies]
-rusoto_dynamodb = { version = "0.46", default-features = false }
-aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main" }
+rusoto_dynamodb = { version = "0.46", default-features = false, optional = true }
+aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", optional = true }
 serde = "1"
 
 [dev-dependencies]
@@ -23,3 +23,8 @@ rusoto_core = { version = "0.46", default-features = false, features = ["rustls"
 serde_bytes = "0.11"
 serde_derive = "1"
 serde_json = "1"
+
+[features]
+default = ["rusoto"]
+rusoto = ["rusoto_dynamodb"]
+aws_sdk = ["aws-sdk-dynamodb"]

--- a/src/generic/de/tests.rs
+++ b/src/generic/de/tests.rs
@@ -1,525 +1,527 @@
 #![allow(clippy::float_cmp, clippy::redundant_clone, clippy::unit_cmp)]
 
-use crate::rusoto_dynamodb::from_attribute_value;
-use maplit::hashmap;
-use rusoto_dynamodb::AttributeValue;
-use serde_derive::{Deserialize, Serialize};
-use std::collections::HashMap;
+#[cfg(test)]
+#[cfg(feature = "rusoto")]
+mod tests {
+    use crate::rusoto_dynamodb::from_attribute_value;
+    use maplit::hashmap;
+    use rusoto_dynamodb::AttributeValue;
+    use serde_derive::{Deserialize, Serialize};
+    use std::collections::HashMap;
 
-macro_rules! assert_identical_json {
-    ($ty:ty, $expr:expr) => {
-        assert_identical_json::<$ty>($expr, $expr);
-    };
-}
-
-/// Assert that the expression is the same whether it is deserialized directly, or deserialized
-/// first to json and then to an attribute value
-#[track_caller]
-fn assert_identical_json<T>(t1: AttributeValue, t2: AttributeValue)
-where
-    T: serde::de::DeserializeOwned,
-    T: PartialEq,
-    T: std::fmt::Debug,
-{
-    let direct_result: T = from_attribute_value(t1).unwrap();
-    let indirect_result: T = serde_json::from_value(from_attribute_value(t2).unwrap()).unwrap();
-    assert_eq!(direct_result, indirect_result);
-}
-
-#[test]
-fn deserialize_string() {
-    let attribute_value = AttributeValue {
-        s: Some(String::from("Value")),
-        ..AttributeValue::default()
-    };
-
-    let result: String = from_attribute_value(attribute_value.clone()).unwrap();
-
-    assert_eq!(result, "Value");
-
-    assert_identical_json!(String, attribute_value.clone());
-}
-
-#[test]
-fn deserialize_num() {
-    macro_rules! deserialize_num {
-        ($ty:ty, $n:expr) => {
-            let attribute_value = AttributeValue {
-                n: Some(String::from(stringify!($n))),
-                ..AttributeValue::default()
-            };
-
-            assert_eq!(
-                from_attribute_value::<$ty>(attribute_value.clone()).unwrap(),
-                $n
-            );
-
-            assert_identical_json!($ty, attribute_value.clone());
+    macro_rules! assert_identical_json {
+        ($ty:ty, $expr:expr) => {
+            assert_identical_json::<$ty>($expr, $expr);
         };
     }
-
-    deserialize_num!(u8, 2);
-    deserialize_num!(i8, -2);
-    deserialize_num!(u16, 2);
-    deserialize_num!(i16, -2);
-    deserialize_num!(u32, 2);
-    deserialize_num!(i32, -2);
-    deserialize_num!(u64, 2);
-    deserialize_num!(i64, -2);
-    deserialize_num!(f32, 1.1);
-    deserialize_num!(f64, 1.1);
-}
-
-#[test]
-fn deserialize_bool() {
-    let attribute_value = AttributeValue {
-        bool: Some(true),
-        ..AttributeValue::default()
-    };
-    let result: bool = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(result, true);
-    assert_identical_json!(bool, attribute_value.clone());
-
-    let attribute_value = AttributeValue {
-        bool: Some(false),
-        ..AttributeValue::default()
-    };
-    let result: bool = from_attribute_value(AttributeValue {
-        bool: Some(false),
-        ..AttributeValue::default()
-    })
-    .unwrap();
-    assert_eq!(result, false);
-    assert_identical_json!(bool, attribute_value.clone());
-}
-
-#[test]
-fn deserialize_char() {
-    let attribute_value = AttributeValue {
-        s: Some(String::from("🥳")),
-        ..AttributeValue::default()
-    };
-    let result: char = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(result, '🥳');
-    assert_identical_json!(char, attribute_value.clone());
-}
-
-#[test]
-fn deserialize_unit() {
-    let attribute_value = AttributeValue {
-        null: Some(true),
-        ..AttributeValue::default()
-    };
-    let result: () = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(result, ());
-    assert_identical_json!((), attribute_value.clone());
-}
-
-#[test]
-fn deserialize_option() {
-    let attribute_value = AttributeValue {
-        null: Some(true),
-        ..AttributeValue::default()
-    };
-    let result: Option<u8> = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(result, None);
-    assert_identical_json!(Option<u8>, attribute_value.clone());
-
-    let attribute_value = AttributeValue {
-        n: Some(String::from("1")),
-        ..AttributeValue::default()
-    };
-    let result: Option<u8> = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(result, Some(1));
-    assert_identical_json!(Option<u8>, attribute_value.clone());
-}
-
-#[test]
-fn deserialize_struct_with_string() {
-    #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
-    struct Subject {
-        value: String,
+    /// Assert that the expression is the same whether it is deserialized directly, or deserialized
+    /// first to json and then to an attribute value
+    #[track_caller]
+    fn assert_identical_json<T>(t1: AttributeValue, t2: AttributeValue)
+    where
+        T: serde::de::DeserializeOwned,
+        T: PartialEq,
+        T: std::fmt::Debug,
+    {
+        let direct_result: T = from_attribute_value(t1).unwrap();
+        let indirect_result: T = serde_json::from_value(from_attribute_value(t2).unwrap()).unwrap();
+        assert_eq!(direct_result, indirect_result);
     }
 
-    let attribute_value = AttributeValue {
-        m: Some(hashmap! {
-            String::from("value") => AttributeValue {
-                s: Some(String::from("Value")),
-                ..AttributeValue::default()
-            },
-        }),
-        ..AttributeValue::default()
-    };
+    #[test]
+    fn deserialize_string() {
+        let attribute_value = AttributeValue {
+            s: Some(String::from("Value")),
+            ..AttributeValue::default()
+        };
 
-    let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(
-        s,
-        Subject {
-            value: String::from("Value"),
+        let result: String = from_attribute_value(attribute_value.clone()).unwrap();
+
+        assert_eq!(result, "Value");
+
+        assert_identical_json!(String, attribute_value.clone());
+    }
+
+    #[test]
+    fn deserialize_num() {
+        macro_rules! deserialize_num {
+            ($ty:ty, $n:expr) => {
+                let attribute_value = AttributeValue {
+                    n: Some(String::from(stringify!($n))),
+                    ..AttributeValue::default()
+                };
+
+                assert_eq!(
+                    from_attribute_value::<$ty>(attribute_value.clone()).unwrap(),
+                    $n
+                );
+
+                assert_identical_json!($ty, attribute_value.clone());
+            };
         }
-    );
-    assert_identical_json!(Subject, attribute_value.clone());
-}
 
-#[test]
-fn deserialize_bytes() {
-    #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
-    struct Subject {
-        #[serde(with = "serde_bytes")]
-        value: Vec<u8>,
+        deserialize_num!(u8, 2);
+        deserialize_num!(i8, -2);
+        deserialize_num!(u16, 2);
+        deserialize_num!(i16, -2);
+        deserialize_num!(u32, 2);
+        deserialize_num!(i32, -2);
+        deserialize_num!(u64, 2);
+        deserialize_num!(i64, -2);
+        deserialize_num!(f32, 1.1);
+        deserialize_num!(f64, 1.1);
     }
 
-    let attribute_value = AttributeValue {
-        m: Some(hashmap! {
-            String::from("value") => AttributeValue {
-                b: Some(vec![116, 101, 115, 116, 0, 0, 0, 0].into()),
-                ..AttributeValue::default()
-            },
-        }),
-        ..AttributeValue::default()
-    };
+    #[test]
+    fn deserialize_bool() {
+        let attribute_value = AttributeValue {
+            bool: Some(true),
+            ..AttributeValue::default()
+        };
+        let result: bool = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(result, true);
+        assert_identical_json!(bool, attribute_value.clone());
 
-    let s: Subject = from_attribute_value(attribute_value).unwrap();
-    assert_eq!(
-        s,
-        Subject {
-            value: vec![116, 101, 115, 116, 0, 0, 0, 0],
+        let attribute_value = AttributeValue {
+            bool: Some(false),
+            ..AttributeValue::default()
+        };
+        let result: bool = from_attribute_value(AttributeValue {
+            bool: Some(false),
+            ..AttributeValue::default()
+        })
+        .unwrap();
+        assert_eq!(result, false);
+        assert_identical_json!(bool, attribute_value.clone());
+    }
+
+    #[test]
+    fn deserialize_char() {
+        let attribute_value = AttributeValue {
+            s: Some(String::from("🥳")),
+            ..AttributeValue::default()
+        };
+        let result: char = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(result, '🥳');
+        assert_identical_json!(char, attribute_value.clone());
+    }
+
+    #[test]
+    fn deserialize_unit() {
+        let attribute_value = AttributeValue {
+            null: Some(true),
+            ..AttributeValue::default()
+        };
+        let result: () = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(result, ());
+        assert_identical_json!((), attribute_value.clone());
+    }
+
+    #[test]
+    fn deserialize_option() {
+        let attribute_value = AttributeValue {
+            null: Some(true),
+            ..AttributeValue::default()
+        };
+        let result: Option<u8> = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(result, None);
+        assert_identical_json!(Option<u8>, attribute_value.clone());
+
+        let attribute_value = AttributeValue {
+            n: Some(String::from("1")),
+            ..AttributeValue::default()
+        };
+        let result: Option<u8> = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(result, Some(1));
+        assert_identical_json!(Option<u8>, attribute_value.clone());
+    }
+
+    #[test]
+    fn deserialize_struct_with_string() {
+        #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+        struct Subject {
+            value: String,
         }
-    );
-}
 
-#[test]
-fn deserialize_byte_arrays() {
-    #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
-    struct Subject {
-        value: Vec<serde_bytes::ByteBuf>,
-    }
+        let attribute_value = AttributeValue {
+            m: Some(hashmap! {
+                String::from("value") => AttributeValue {
+                    s: Some(String::from("Value")),
+                    ..AttributeValue::default()
+                },
+            }),
+            ..AttributeValue::default()
+        };
 
-    let attribute_value = AttributeValue {
-        m: Some(hashmap! {
-            String::from("value") => AttributeValue {
-                bs: Some(vec![
-                    vec![116, 101, 115, 116, 0, 0, 0, 0].into(),
-                    vec![2].into(),
-                    vec![0, 0, 0, 0].into(),
-                ]),
-                ..AttributeValue::default()
-            },
-        }),
-        ..AttributeValue::default()
-    };
-
-    let s: Subject = from_attribute_value(attribute_value).unwrap();
-    assert_eq!(
-        s,
-        Subject {
-            value: vec![
-                serde_bytes::ByteBuf::from(vec![116, 101, 115, 116, 0, 0, 0, 0]),
-                serde_bytes::ByteBuf::from(vec![2]),
-                serde_bytes::ByteBuf::from(vec![0, 0, 0, 0]),
-            ],
-        }
-    );
-}
-
-#[test]
-fn deserialize_struct_with_aws_extra_data() {
-    #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
-    struct Subject {
-        id: String,
-        value: u64,
-    }
-
-    let attribute_value = AttributeValue {
-        m: Some(hashmap! {
-            String::from("id") => AttributeValue {
-                s: Some(String::from("test-4")),
-                ..AttributeValue::default()
-            },
-            String::from("value") => AttributeValue {
-                n: Some(String::from("42")),
-                ..AttributeValue::default()
-            },
-            String::from("aws:rep:deleting") => AttributeValue {
-                bool: Some(false),
-                ..AttributeValue::default()
-            },
-            String::from("aws:rep:updateregion") => AttributeValue {
-                s: Some(String::from("us-west-2")),
-                ..AttributeValue::default()
-            },
-            String::from("aws:rep:updatetime") => AttributeValue {
-                n: Some(String::from("1565723640.315001")),
-                ..AttributeValue::default()
-            },
-        }),
-        ..AttributeValue::default()
-    };
-
-    let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(
-        s,
-        Subject {
-            id: String::from("test-4"),
-            value: 42,
-        }
-    );
-    assert_identical_json!(Subject, attribute_value.clone());
-}
-
-#[test]
-fn deserialize_array_of_struct_with_string() {
-    #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
-    struct Subject {
-        value: String,
-    }
-
-    let attribute_value = AttributeValue {
-        l: Some(vec![
-            AttributeValue {
-                m: Some(hashmap! {
-                    String::from("value") => AttributeValue { s: Some(String::from("1")), ..AttributeValue::default() },
-                }),
-                ..AttributeValue::default()
-            },
-            AttributeValue {
-                m: Some(hashmap! {
-                    String::from("value") => AttributeValue { s: Some(String::from("2")), ..AttributeValue::default() },
-                }),
-                ..AttributeValue::default()
-            },
-            AttributeValue {
-                m: Some(hashmap! {
-                    String::from("value") => AttributeValue { s: Some(String::from("3")), ..AttributeValue::default() },
-                }),
-                ..AttributeValue::default()
-            },
-        ]),
-        ..AttributeValue::default()
-    };
-
-    let s: Vec<Subject> = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(
-        s,
-        vec![
+        let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(
+            s,
             Subject {
-                value: String::from("1"),
-            },
+                value: String::from("Value"),
+            }
+        );
+        assert_identical_json!(Subject, attribute_value.clone());
+    }
+
+    #[test]
+    fn deserialize_bytes() {
+        #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+        struct Subject {
+            #[serde(with = "serde_bytes")]
+            value: Vec<u8>,
+        }
+
+        let attribute_value = AttributeValue {
+            m: Some(hashmap! {
+                String::from("value") => AttributeValue {
+                    b: Some(vec![116, 101, 115, 116, 0, 0, 0, 0].into()),
+                    ..AttributeValue::default()
+                },
+            }),
+            ..AttributeValue::default()
+        };
+
+        let s: Subject = from_attribute_value(attribute_value).unwrap();
+        assert_eq!(
+            s,
             Subject {
-                value: String::from("2"),
-            },
+                value: vec![116, 101, 115, 116, 0, 0, 0, 0],
+            }
+        );
+    }
+
+    #[test]
+    fn deserialize_byte_arrays() {
+        #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+        struct Subject {
+            value: Vec<serde_bytes::ByteBuf>,
+        }
+
+        let attribute_value = AttributeValue {
+            m: Some(hashmap! {
+                String::from("value") => AttributeValue {
+                    bs: Some(vec![
+                        vec![116, 101, 115, 116, 0, 0, 0, 0].into(),
+                        vec![2].into(),
+                        vec![0, 0, 0, 0].into(),
+                    ]),
+                    ..AttributeValue::default()
+                },
+            }),
+            ..AttributeValue::default()
+        };
+
+        let s: Subject = from_attribute_value(attribute_value).unwrap();
+        assert_eq!(
+            s,
             Subject {
-                value: String::from("3"),
-            },
-        ]
-    );
-    assert_identical_json!(Vec<Subject>, attribute_value.clone());
-}
+                value: vec![
+                    serde_bytes::ByteBuf::from(vec![116, 101, 115, 116, 0, 0, 0, 0]),
+                    serde_bytes::ByteBuf::from(vec![2]),
+                    serde_bytes::ByteBuf::from(vec![0, 0, 0, 0]),
+                ],
+            }
+        );
+    }
 
-#[test]
-fn deserialize_list() {
-    let attribute_value = AttributeValue {
-        l: Some(vec![
-            AttributeValue {
-                s: Some(String::from("1")),
-                ..AttributeValue::default()
-            },
-            AttributeValue {
-                s: Some(String::from("2")),
-                ..AttributeValue::default()
-            },
-            AttributeValue {
-                s: Some(String::from("3")),
-                ..AttributeValue::default()
-            },
-        ]),
-        ..AttributeValue::default()
-    };
+    #[test]
+    fn deserialize_struct_with_aws_extra_data() {
+        #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+        struct Subject {
+            id: String,
+            value: u64,
+        }
 
-    let s: Vec<String> = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(s, vec!["1", "2", "3"]);
-    assert_identical_json!(Vec<String>, attribute_value.clone());
-}
+        let attribute_value = AttributeValue {
+            m: Some(hashmap! {
+                String::from("id") => AttributeValue {
+                    s: Some(String::from("test-4")),
+                    ..AttributeValue::default()
+                },
+                String::from("value") => AttributeValue {
+                    n: Some(String::from("42")),
+                    ..AttributeValue::default()
+                },
+                String::from("aws:rep:deleting") => AttributeValue {
+                    bool: Some(false),
+                    ..AttributeValue::default()
+                },
+                String::from("aws:rep:updateregion") => AttributeValue {
+                    s: Some(String::from("us-west-2")),
+                    ..AttributeValue::default()
+                },
+                String::from("aws:rep:updatetime") => AttributeValue {
+                    n: Some(String::from("1565723640.315001")),
+                    ..AttributeValue::default()
+                },
+            }),
+            ..AttributeValue::default()
+        };
 
-#[test]
-fn deserialize_string_list() {
-    let attribute_value = AttributeValue {
-        ss: Some(vec![
-            String::from("1"),
-            String::from("2"),
-            String::from("3"),
-        ]),
-        ..AttributeValue::default()
-    };
+        let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(
+            s,
+            Subject {
+                id: String::from("test-4"),
+                value: 42,
+            }
+        );
+        assert_identical_json!(Subject, attribute_value.clone());
+    }
 
-    let v: Vec<String> = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(v, vec!["1", "2", "3"]);
-    assert_identical_json!(Vec<String>, attribute_value.clone());
-}
+    #[test]
+    fn deserialize_array_of_struct_with_string() {
+        #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+        struct Subject {
+            value: String,
+        }
 
-#[test]
-fn deserialize_int_list() {
-    let attribute_value = AttributeValue {
-        ns: Some(vec![
-            String::from("1"),
-            String::from("2"),
-            String::from("3"),
-        ]),
-        ..AttributeValue::default()
-    };
+        let attribute_value = AttributeValue {
+            l: Some(vec![
+                AttributeValue {
+                    m: Some(hashmap! {
+                        String::from("value") => AttributeValue { s: Some(String::from("1")), ..AttributeValue::default() },
+                    }),
+                    ..AttributeValue::default()
+                },
+                AttributeValue {
+                    m: Some(hashmap! {
+                        String::from("value") => AttributeValue { s: Some(String::from("2")), ..AttributeValue::default() },
+                    }),
+                    ..AttributeValue::default()
+                },
+                AttributeValue {
+                    m: Some(hashmap! {
+                        String::from("value") => AttributeValue { s: Some(String::from("3")), ..AttributeValue::default() },
+                    }),
+                    ..AttributeValue::default()
+                },
+            ]),
+            ..AttributeValue::default()
+        };
 
-    let v: Vec<u64> = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(v, vec![1, 2, 3]);
-    assert_identical_json!(Vec<u64>, attribute_value.clone());
-}
+        let s: Vec<Subject> = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(
+            s,
+            vec![
+                Subject {
+                    value: String::from("1"),
+                },
+                Subject {
+                    value: String::from("2"),
+                },
+                Subject {
+                    value: String::from("3"),
+                },
+            ]
+        );
+        assert_identical_json!(Vec<Subject>, attribute_value.clone());
+    }
 
-#[test]
-fn deserialize_float_list() {
-    let attribute_value = AttributeValue {
-        ns: Some(vec![
-            String::from("1"),
-            String::from("2"),
-            String::from("0.5"),
-        ]),
-        ..AttributeValue::default()
-    };
+    #[test]
+    fn deserialize_list() {
+        let attribute_value = AttributeValue {
+            l: Some(vec![
+                AttributeValue {
+                    s: Some(String::from("1")),
+                    ..AttributeValue::default()
+                },
+                AttributeValue {
+                    s: Some(String::from("2")),
+                    ..AttributeValue::default()
+                },
+                AttributeValue {
+                    s: Some(String::from("3")),
+                    ..AttributeValue::default()
+                },
+            ]),
+            ..AttributeValue::default()
+        };
 
-    let v: Vec<f64> = from_attribute_value(attribute_value).unwrap();
-    assert_eq!(v.len(), 3);
-    assert!(0.9 < v[0] && v[0] < 1.1);
-    assert!(1.9 < v[1] && v[1] < 2.1);
-    assert!(0.4 < v[2] && v[2] < 0.6);
-}
+        let s: Vec<String> = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(s, vec!["1", "2", "3"]);
+        assert_identical_json!(Vec<String>, attribute_value.clone());
+    }
 
-#[test]
-fn deserialize_unit_struct() {
-    #[derive(Debug, Deserialize, Eq, PartialEq)]
-    struct Subject;
+    #[test]
+    fn deserialize_string_list() {
+        let attribute_value = AttributeValue {
+            ss: Some(vec![
+                String::from("1"),
+                String::from("2"),
+                String::from("3"),
+            ]),
+            ..AttributeValue::default()
+        };
 
-    let attribute_value = AttributeValue {
-        null: Some(true),
-        ..AttributeValue::default()
-    };
+        let v: Vec<String> = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(v, vec!["1", "2", "3"]);
+        assert_identical_json!(Vec<String>, attribute_value.clone());
+    }
 
-    let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(s, Subject);
+    #[test]
+    fn deserialize_int_list() {
+        let attribute_value = AttributeValue {
+            ns: Some(vec![
+                String::from("1"),
+                String::from("2"),
+                String::from("3"),
+            ]),
+            ..AttributeValue::default()
+        };
 
-    assert_identical_json!(Subject, attribute_value.clone())
-}
+        let v: Vec<u64> = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(v, vec![1, 2, 3]);
+        assert_identical_json!(Vec<u64>, attribute_value.clone());
+    }
 
-#[test]
-fn deserialize_newtype_struct() {
-    #[derive(Debug, Deserialize, Eq, PartialEq)]
-    struct Subject(u8);
+    #[test]
+    fn deserialize_float_list() {
+        let attribute_value = AttributeValue {
+            ns: Some(vec![
+                String::from("1"),
+                String::from("2"),
+                String::from("0.5"),
+            ]),
+            ..AttributeValue::default()
+        };
 
-    let attribute_value = AttributeValue {
-        n: Some(String::from("1")),
-        ..AttributeValue::default()
-    };
+        let v: Vec<f64> = from_attribute_value(attribute_value).unwrap();
+        assert_eq!(v.len(), 3);
+        assert!(0.9 < v[0] && v[0] < 1.1);
+        assert!(1.9 < v[1] && v[1] < 2.1);
+        assert!(0.4 < v[2] && v[2] < 0.6);
+    }
 
-    let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(s, Subject(1));
+    #[test]
+    fn deserialize_unit_struct() {
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        struct Subject;
 
-    assert_identical_json!(Subject, attribute_value.clone())
-}
+        let attribute_value = AttributeValue {
+            null: Some(true),
+            ..AttributeValue::default()
+        };
 
-#[test]
-fn deserialize_tuple_struct() {
-    #[derive(Debug, Deserialize, Eq, PartialEq)]
-    struct Subject(u8, u8);
+        let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(s, Subject);
 
-    let attribute_value = AttributeValue {
-        l: Some(vec![
-            AttributeValue {
-                n: Some(String::from("1")),
-                ..AttributeValue::default()
-            },
-            AttributeValue {
-                n: Some(String::from("2")),
-                ..AttributeValue::default()
-            },
-        ]),
-        ..AttributeValue::default()
-    };
+        assert_identical_json!(Subject, attribute_value.clone())
+    }
 
-    let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(s, Subject(1, 2));
+    #[test]
+    fn deserialize_newtype_struct() {
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        struct Subject(u8);
 
-    assert_identical_json!(Subject, attribute_value.clone())
-}
+        let attribute_value = AttributeValue {
+            n: Some(String::from("1")),
+            ..AttributeValue::default()
+        };
 
-#[test]
-fn deserialize_tuple() {
-    let attribute_value = AttributeValue {
-        l: Some(vec![
-            AttributeValue {
-                n: Some(String::from("1")),
-                ..AttributeValue::default()
-            },
-            AttributeValue {
-                n: Some(String::from("2")),
-                ..AttributeValue::default()
-            },
-        ]),
-        ..AttributeValue::default()
-    };
+        let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(s, Subject(1));
 
-    let s: (usize, usize) = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(s, (1, 2));
+        assert_identical_json!(Subject, attribute_value.clone())
+    }
 
-    assert_identical_json!((usize, usize), attribute_value.clone())
-}
+    #[test]
+    fn deserialize_tuple_struct() {
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        struct Subject(u8, u8);
 
-#[test]
-fn deserialize_map_with_strings() {
-    let attribute_value = AttributeValue {
-        m: Some(hashmap! {
-            String::from("one") => AttributeValue {
-                n: Some(String::from("1")),
-                ..AttributeValue::default()
-            },
-            String::from("two") => AttributeValue {
-                n: Some(String::from("2")),
-                ..AttributeValue::default()
-            },
-        }),
-        ..AttributeValue::default()
-    };
+        let attribute_value = AttributeValue {
+            l: Some(vec![
+                AttributeValue {
+                    n: Some(String::from("1")),
+                    ..AttributeValue::default()
+                },
+                AttributeValue {
+                    n: Some(String::from("2")),
+                    ..AttributeValue::default()
+                },
+            ]),
+            ..AttributeValue::default()
+        };
 
-    let s: HashMap<String, usize> = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(
-        s,
-        hashmap! { String::from("one") => 1, String::from("two") => 2 }
-    );
+        let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(s, Subject(1, 2));
 
-    assert_identical_json!(HashMap<String, usize>, attribute_value.clone())
-}
+        assert_identical_json!(Subject, attribute_value.clone())
+    }
 
-#[test]
-fn deserialize_maps_of_various_types() {
-    let attribute_value = AttributeValue {
-        m: Some(hashmap! {
-            String::from("1") => AttributeValue {
-                s: Some(String::from("one")),
-                ..AttributeValue::default()
-            },
-            String::from("2") => AttributeValue {
-                s: Some(String::from("two")),
-                ..AttributeValue::default()
-            },
-        }),
-        ..AttributeValue::default()
-    };
+    #[test]
+    fn deserialize_tuple() {
+        let attribute_value = AttributeValue {
+            l: Some(vec![
+                AttributeValue {
+                    n: Some(String::from("1")),
+                    ..AttributeValue::default()
+                },
+                AttributeValue {
+                    n: Some(String::from("2")),
+                    ..AttributeValue::default()
+                },
+            ]),
+            ..AttributeValue::default()
+        };
 
-    let s: HashMap<usize, String> = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(
-        s,
-        hashmap! { 1 => String::from("one"), 2 => String::from("two") }
-    );
+        let s: (usize, usize) = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(s, (1, 2));
 
-    assert_identical_json!(HashMap<usize, String>, attribute_value.clone());
+        assert_identical_json!((usize, usize), attribute_value.clone())
+    }
 
-    macro_rules! test_map {
+    #[test]
+    fn deserialize_map_with_strings() {
+        let attribute_value = AttributeValue {
+            m: Some(hashmap! {
+                String::from("one") => AttributeValue {
+                    n: Some(String::from("1")),
+                    ..AttributeValue::default()
+                },
+                String::from("two") => AttributeValue {
+                    n: Some(String::from("2")),
+                    ..AttributeValue::default()
+                },
+            }),
+            ..AttributeValue::default()
+        };
+
+        let s: HashMap<String, usize> = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(
+            s,
+            hashmap! { String::from("one") => 1, String::from("two") => 2 }
+        );
+
+        assert_identical_json!(HashMap<String, usize>, attribute_value.clone())
+    }
+
+    #[test]
+    fn deserialize_maps_of_various_types() {
+        let attribute_value = AttributeValue {
+            m: Some(hashmap! {
+                String::from("1") => AttributeValue {
+                    s: Some(String::from("one")),
+                    ..AttributeValue::default()
+                },
+                String::from("2") => AttributeValue {
+                    s: Some(String::from("two")),
+                    ..AttributeValue::default()
+                },
+            }),
+            ..AttributeValue::default()
+        };
+
+        let s: HashMap<usize, String> = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(
+            s,
+            hashmap! { 1 => String::from("one"), 2 => String::from("two") }
+        );
+
+        assert_identical_json!(HashMap<usize, String>, attribute_value.clone());
+
+        macro_rules! test_map {
         ($ty:ty, $($s:literal => $r:expr),*) => {
             let attribute_value = AttributeValue {
                 m: Some(hashmap! {
@@ -547,187 +549,192 @@ fn deserialize_maps_of_various_types() {
         }
     }
 
-    test_map!(usize, "1" => 1, "2" => 2);
-    test_map!(i8, "-1" => -1, "-2" => -2);
-    test_map!(char, "a" => 'a', "b" => 'b');
+        test_map!(usize, "1" => 1, "2" => 2);
+        test_map!(i8, "-1" => -1, "-2" => -2);
+        test_map!(char, "a" => 'a', "b" => 'b');
 
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-    struct Struct(i64);
-    test_map!(Struct, "1" => Struct(1), "2" => Struct(2));
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+        struct Struct(i64);
+        test_map!(Struct, "1" => Struct(1), "2" => Struct(2));
 
-    {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-        /// Externally tagged
-        enum VariantType {
-            Unit1,
-            Unit2,
+        {
+            #[derive(
+                Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+            )]
+            /// Externally tagged
+            enum VariantType {
+                Unit1,
+                Unit2,
+            }
+
+            test_map!(VariantType, "Unit1" => VariantType::Unit1, "Unit2" => VariantType::Unit2);
         }
 
-        test_map!(VariantType, "Unit1" => VariantType::Unit1, "Unit2" => VariantType::Unit2);
+        {
+            #[derive(
+                Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+            )]
+            #[serde(untagged)]
+            /// Untagged
+            enum VariantType {
+                Newtype(String),
+            }
+
+            test_map!(VariantType, "one" => VariantType::Newtype(String::from("one")));
+        }
     }
 
-    {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-        #[serde(untagged)]
-        /// Untagged
-        enum VariantType {
-            Newtype(String),
+    #[test]
+    fn deserialize_enum_unit() {
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        enum Subject {
+            Unit,
         }
 
-        test_map!(VariantType, "one" => VariantType::Newtype(String::from("one")));
-    }
-}
+        let attribute_value = AttributeValue {
+            s: Some(String::from("Unit")),
+            ..AttributeValue::default()
+        };
 
-#[test]
-fn deserialize_enum_unit() {
-    #[derive(Debug, Deserialize, Eq, PartialEq)]
-    enum Subject {
-        Unit,
-    }
+        let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(s, Subject::Unit);
 
-    let attribute_value = AttributeValue {
-        s: Some(String::from("Unit")),
-        ..AttributeValue::default()
-    };
-
-    let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(s, Subject::Unit);
-
-    assert_identical_json!(Subject, attribute_value.clone())
-}
-
-#[test]
-fn deserialize_enum_newtype() {
-    #[derive(Debug, Deserialize, Eq, PartialEq)]
-    enum Subject {
-        Newtype(u8),
+        assert_identical_json!(Subject, attribute_value.clone())
     }
 
-    let attribute_value = AttributeValue {
-        m: Some(hashmap! {
-            String::from("Newtype") => AttributeValue {
-                n: Some(String::from("1")),
-                ..AttributeValue::default()
-            },
-        }),
-        ..AttributeValue::default()
-    };
+    #[test]
+    fn deserialize_enum_newtype() {
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        enum Subject {
+            Newtype(u8),
+        }
 
-    let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(s, Subject::Newtype(1));
+        let attribute_value = AttributeValue {
+            m: Some(hashmap! {
+                String::from("Newtype") => AttributeValue {
+                    n: Some(String::from("1")),
+                    ..AttributeValue::default()
+                },
+            }),
+            ..AttributeValue::default()
+        };
 
-    assert_identical_json!(Subject, attribute_value.clone())
-}
+        let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(s, Subject::Newtype(1));
 
-#[test]
-fn deserialize_enum_tuple() {
-    #[derive(Debug, Deserialize, Eq, PartialEq)]
-    enum Subject {
-        Tuple(u8, u8),
+        assert_identical_json!(Subject, attribute_value.clone())
     }
 
-    let attribute_value = AttributeValue {
-        m: Some(hashmap! {
-            String::from("Tuple") => AttributeValue {
-                l: Some(vec![
-                    AttributeValue {
-                        n: Some(String::from("1")),
-                        ..AttributeValue::default()
-                    },
-                    AttributeValue {
-                        n: Some(String::from("2")),
-                        ..AttributeValue::default()
-                    },
-                ]),
-                ..AttributeValue::default()
-            },
-        }),
-        ..AttributeValue::default()
-    };
+    #[test]
+    fn deserialize_enum_tuple() {
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        enum Subject {
+            Tuple(u8, u8),
+        }
 
-    let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(s, Subject::Tuple(1, 2));
+        let attribute_value = AttributeValue {
+            m: Some(hashmap! {
+                String::from("Tuple") => AttributeValue {
+                    l: Some(vec![
+                        AttributeValue {
+                            n: Some(String::from("1")),
+                            ..AttributeValue::default()
+                        },
+                        AttributeValue {
+                            n: Some(String::from("2")),
+                            ..AttributeValue::default()
+                        },
+                    ]),
+                    ..AttributeValue::default()
+                },
+            }),
+            ..AttributeValue::default()
+        };
 
-    assert_identical_json!(Subject, attribute_value.clone())
-}
+        let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(s, Subject::Tuple(1, 2));
 
-#[test]
-fn deserialize_enum_struct_variant() {
-    #[derive(Debug, Deserialize, Eq, PartialEq)]
-    enum Subject {
-        Structy { one: u8, two: u8 },
+        assert_identical_json!(Subject, attribute_value.clone())
     }
 
-    let attribute_value = AttributeValue {
-        m: Some(hashmap! {
-            String::from("Structy") => AttributeValue {
-                m: Some(hashmap! {
-                    String::from("one") => AttributeValue {
-                        n: Some(String::from("1")),
-                        ..AttributeValue::default()
-                    },
-                    String::from("two") => AttributeValue {
-                        n: Some(String::from("2")),
-                        ..AttributeValue::default()
-                    },
-                }),
-                ..AttributeValue::default()
-            },
-        }),
-        ..AttributeValue::default()
-    };
+    #[test]
+    fn deserialize_enum_struct_variant() {
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        enum Subject {
+            Structy { one: u8, two: u8 },
+        }
 
-    let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(s, Subject::Structy { one: 1, two: 2 });
+        let attribute_value = AttributeValue {
+            m: Some(hashmap! {
+                String::from("Structy") => AttributeValue {
+                    m: Some(hashmap! {
+                        String::from("one") => AttributeValue {
+                            n: Some(String::from("1")),
+                            ..AttributeValue::default()
+                        },
+                        String::from("two") => AttributeValue {
+                            n: Some(String::from("2")),
+                            ..AttributeValue::default()
+                        },
+                    }),
+                    ..AttributeValue::default()
+                },
+            }),
+            ..AttributeValue::default()
+        };
 
-    assert_identical_json!(Subject, attribute_value.clone())
-}
+        let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(s, Subject::Structy { one: 1, two: 2 });
 
-#[test]
-fn deserialize_internally_tagged_enum() {
-    #[derive(Debug, Deserialize, Eq, PartialEq)]
-    #[serde(tag = "type")]
-    enum Subject {
-        One { one: u64 },
-        Two { two: u8 },
+        assert_identical_json!(Subject, attribute_value.clone())
     }
 
-    let attribute_value = AttributeValue {
-        m: Some(hashmap! {
-            String::from("type") => AttributeValue {
-                s: Some(String::from("One")),
-                ..AttributeValue::default()
-            },
-            String::from("one") => AttributeValue {
-                n: Some(String::from("1")),
-                ..AttributeValue::default()
-            },
-        }),
-        ..AttributeValue::default()
-    };
+    #[test]
+    fn deserialize_internally_tagged_enum() {
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        #[serde(tag = "type")]
+        enum Subject {
+            One { one: u64 },
+            Two { two: u8 },
+        }
 
-    let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(s, Subject::One { one: 1 });
+        let attribute_value = AttributeValue {
+            m: Some(hashmap! {
+                String::from("type") => AttributeValue {
+                    s: Some(String::from("One")),
+                    ..AttributeValue::default()
+                },
+                String::from("one") => AttributeValue {
+                    n: Some(String::from("1")),
+                    ..AttributeValue::default()
+                },
+            }),
+            ..AttributeValue::default()
+        };
 
-    assert_identical_json!(Subject, attribute_value.clone())
-}
+        let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(s, Subject::One { one: 1 });
 
-#[test]
-fn deserialize_chrono_datetime() {
-    use chrono::{DateTime, Utc};
+        assert_identical_json!(Subject, attribute_value.clone())
+    }
 
-    let attribute_value = AttributeValue {
-        s: Some(String::from("1985-04-21T18:34:13.449057039Z")),
-        ..AttributeValue::default()
-    };
+    #[test]
+    fn deserialize_chrono_datetime() {
+        use chrono::{DateTime, Utc};
 
-    let s: DateTime<Utc> = from_attribute_value(attribute_value.clone()).unwrap();
-    assert_eq!(
-        s,
-        DateTime::parse_from_rfc3339("1985-04-21T18:34:13.449057039Z")
-            .unwrap()
-            .with_timezone(&Utc)
-    );
+        let attribute_value = AttributeValue {
+            s: Some(String::from("1985-04-21T18:34:13.449057039Z")),
+            ..AttributeValue::default()
+        };
 
-    assert_identical_json!(DateTime<Utc>, attribute_value.clone())
+        let s: DateTime<Utc> = from_attribute_value(attribute_value.clone()).unwrap();
+        assert_eq!(
+            s,
+            DateTime::parse_from_rfc3339("1985-04-21T18:34:13.449057039Z")
+                .unwrap()
+                .with_timezone(&Utc)
+        );
+
+        assert_identical_json!(DateTime<Utc>, attribute_value.clone())
+    }
 }

--- a/src/generic/ser/tests.rs
+++ b/src/generic/ser/tests.rs
@@ -1,610 +1,624 @@
 #![allow(clippy::float_cmp, clippy::redundant_clone)]
 
-use crate::rusoto_dynamodb::{to_attribute_value, to_item};
-use maplit::hashmap;
-use rusoto_dynamodb::AttributeValue;
-use serde::Serialize;
-use serde_derive::Deserialize;
+#[cfg(test)]
+#[cfg(feature = "rusoto")]
+mod tests {
 
-macro_rules! assert_identical_json {
-    ($expr:expr) => {
-        assert_identical_json($expr, $expr);
-    };
-}
+    use crate::rusoto_dynamodb::{to_attribute_value, to_item};
+    use maplit::hashmap;
+    use rusoto_dynamodb::AttributeValue;
+    use serde::Serialize;
+    use serde_derive::Deserialize;
 
-/// Assert that the expression is the same whether it is serialized directly, or serialized
-/// first to json and then to an attribute value
-fn assert_identical_json<T>(t1: T, t2: T)
-where
-    T: Serialize,
-{
-    let direct_result = to_attribute_value(t1).unwrap();
-    let indirect_result = to_attribute_value(serde_json::to_value(t2).unwrap()).unwrap();
-    assert_eq!(direct_result, indirect_result);
-}
-
-macro_rules! assert_identical_json_with_error {
-    ($expr:expr) => {
-        assert_identical_json_with_error($expr, $expr);
-    };
-}
-
-fn assert_identical_json_with_error<T>(t1: T, t2: T)
-where
-    T: Serialize,
-{
-    let direct_result = to_attribute_value(t1);
-    let json_result = serde_json::to_value(t2);
-
-    match (direct_result, json_result) {
-        (Ok(direct_result), Ok(json_result)) => match to_attribute_value(json_result) {
-            Ok(indirect_result) => assert_eq!(direct_result, indirect_result),
-            Err(_) => panic!("dynamo, json succeeded, indirect failed"),
-        },
-        (Ok(_), Err(_)) => panic!("dynamo succeeded, json failed"),
-        (Err(_), Ok(_)) => panic!("dynamo failed, json succeeded"),
-        (Err(_), Err(_)) => { /* Both failing is OK. */ }
-    }
-}
-
-#[test]
-fn serialize_string() {
-    let result = to_attribute_value(String::from("Value")).unwrap();
-    assert_eq!(
-        result,
-        AttributeValue {
-            s: Some(String::from("Value")),
-            ..AttributeValue::default()
-        }
-    );
-    assert_identical_json!(String::from("Value"));
-}
-
-#[test]
-fn serialize_num() {
-    macro_rules! serialize_num {
-        ($ty:ty, $n:expr) => {{
-            let v: $ty = $n;
-            let result = to_attribute_value(v).unwrap();
-            assert_eq!(
-                result,
-                AttributeValue {
-                    n: Some(String::from(stringify!($n))),
-                    ..AttributeValue::default()
-                }
-            );
-        }};
-    }
-
-    serialize_num!(i8, -1);
-    serialize_num!(u8, 1);
-    serialize_num!(i16, -1);
-    serialize_num!(u16, 1);
-    serialize_num!(i32, -1);
-    serialize_num!(u32, 1);
-    serialize_num!(i64, -1);
-    serialize_num!(u64, 1);
-    serialize_num!(f32, 1.1);
-    serialize_num!(f64, 1.1);
-}
-
-#[test]
-fn serialize_bool() {
-    let result = to_attribute_value(true).unwrap();
-    assert_eq!(
-        result,
-        AttributeValue {
-            bool: Some(true),
-            ..AttributeValue::default()
-        }
-    );
-    assert_identical_json!(true);
-}
-
-#[test]
-fn serialize_char() {
-    let result = to_attribute_value('🥳').unwrap();
-    assert_eq!(
-        result,
-        AttributeValue {
-            s: Some(String::from("🥳")),
-            ..AttributeValue::default()
-        }
-    );
-    assert_identical_json!('🥳');
-}
-
-#[test]
-fn serialize_unit() {
-    let result = to_attribute_value(()).unwrap();
-    assert_eq!(
-        result,
-        AttributeValue {
-            null: Some(true),
-            ..AttributeValue::default()
-        }
-    );
-    assert_identical_json!(());
-}
-
-#[test]
-fn serialize_option() {
-    let result = to_attribute_value(Some(1_u8)).unwrap();
-    assert_eq!(
-        result,
-        AttributeValue {
-            n: Some(String::from("1")),
-            ..AttributeValue::default()
-        }
-    );
-    assert_identical_json!(Some(1_u8));
-
-    let result = to_attribute_value(Option::<u8>::None).unwrap();
-    assert_eq!(
-        result,
-        AttributeValue {
-            null: Some(true),
-            ..AttributeValue::default()
-        }
-    );
-    assert_identical_json!(Option::<u8>::None);
-}
-
-#[test]
-fn serialize_struct() {
-    #[derive(Clone, Serialize, Deserialize)]
-    struct Subject {
-        value: String,
-    }
-
-    let source = Subject {
-        value: String::from("Value"),
-    };
-
-    let result = to_item(source.clone()).unwrap();
-    assert_eq!(
-        result,
-        hashmap! {
-            String::from("value") => AttributeValue { s: Some(String::from("Value")), ..AttributeValue::default() },
-        }
-    );
-    assert_identical_json!(source.clone());
-}
-
-#[test]
-fn serialize_bytes() {
-    #[derive(Clone, Serialize, Deserialize)]
-    struct Subject {
-        #[serde(with = "serde_bytes")]
-        value: Vec<u8>,
-    }
-
-    let source = Subject {
-        value: vec![116, 101, 115, 116, 0, 0, 0, 0],
-    };
-
-    let result = to_item(source.clone()).unwrap();
-    assert_eq!(
-        result,
-        hashmap! {
-            String::from("value") => AttributeValue { b: Some(vec![116, 101, 115, 116, 0, 0, 0, 0].into()), ..AttributeValue::default() },
-        }
-    );
-}
-
-#[test]
-fn serialize_array_of_structs() {
-    #[derive(Clone, Serialize, Deserialize)]
-    struct Subject {
-        value: String,
-    }
-
-    let mut source = Vec::new();
-    for i in 1..=3 {
-        let s = Subject {
-            value: i.to_string(),
+    macro_rules! assert_identical_json {
+        ($expr:expr) => {
+            assert_identical_json($expr, $expr);
         };
-        source.push(s);
     }
 
-    let result = to_attribute_value(source.clone()).unwrap();
-    assert_eq!(
-        result,
-        AttributeValue {
-            l: Some(vec![
-                AttributeValue {
-                    m: Some(hashmap! {
-                        String::from("value") => AttributeValue { s: Some(String::from("1")), ..AttributeValue::default() },
-                    }),
-                    ..AttributeValue::default()
-                },
-                AttributeValue {
-                    m: Some(hashmap! {
-                        String::from("value") => AttributeValue { s: Some(String::from("2")), ..AttributeValue::default() },
-                    }),
-                    ..AttributeValue::default()
-                },
-                AttributeValue {
-                    m: Some(hashmap! {
-                        String::from("value") => AttributeValue { s: Some(String::from("3")), ..AttributeValue::default() },
-                    }),
-                    ..AttributeValue::default()
-                },
-            ]),
-            ..AttributeValue::default()
-        },
-    );
-    assert_identical_json!(source.clone());
-}
-
-#[test]
-fn serialize_unit_struct() {
-    #[derive(Serialize, Deserialize)]
-    struct Subject;
-
-    let result = to_attribute_value(Subject).unwrap();
-    assert_eq!(
-        result,
-        AttributeValue {
-            null: Some(true),
-            ..AttributeValue::default()
-        }
-    );
-
-    assert_identical_json!(Subject);
-}
-
-#[test]
-fn serialize_newtype_struct() {
-    #[derive(Serialize, Deserialize)]
-    struct Subject(String);
-
-    let result = to_attribute_value(Subject(String::from("one"))).unwrap();
-    assert_eq!(
-        result,
-        AttributeValue {
-            s: Some(String::from("one")),
-            ..AttributeValue::default()
-        }
-    );
-
-    assert_identical_json!(Subject(String::from("one")));
-}
-
-#[test]
-fn serialize_tuple_struct() {
-    #[derive(Serialize, Deserialize)]
-    struct Subject(String, String);
-
-    let result = to_attribute_value(Subject(String::from("one"), String::from("two"))).unwrap();
-    assert_eq!(
-        result,
-        AttributeValue {
-            l: Some(vec![
-                AttributeValue {
-                    s: Some(String::from("one")),
-                    ..AttributeValue::default()
-                },
-                AttributeValue {
-                    s: Some(String::from("two")),
-                    ..AttributeValue::default()
-                },
-            ]),
-            ..AttributeValue::default()
-        }
-    );
-
-    assert_identical_json!(Subject(String::from("one"), String::from("two")));
-}
-
-#[test]
-fn serialize_tuple() {
-    let result = to_attribute_value((String::from("one"), String::from("two"))).unwrap();
-    assert_eq!(
-        result,
-        AttributeValue {
-            l: Some(vec![
-                AttributeValue {
-                    s: Some(String::from("one")),
-                    ..AttributeValue::default()
-                },
-                AttributeValue {
-                    s: Some(String::from("two")),
-                    ..AttributeValue::default()
-                },
-            ]),
-            ..AttributeValue::default()
-        }
-    );
-
-    assert_identical_json!((String::from("one"), String::from("two")));
-}
-
-#[test]
-fn serialize_map_with_strings() {
-    let result =
-        to_attribute_value(hashmap! { String::from("one") => 1, String::from("two") => 2 })
-            .unwrap();
-
-    assert_eq!(
-        result,
-        AttributeValue {
-            m: Some(hashmap! {
-                String::from("one") => AttributeValue {
-                    n: Some(String::from("1")),
-                    ..AttributeValue::default()
-                },
-                String::from("two") => AttributeValue {
-                    n: Some(String::from("2")),
-                    ..AttributeValue::default()
-                },
-            }),
-            ..AttributeValue::default()
-        },
-    );
-
-    assert_identical_json!(hashmap! { String::from("one") => 1, String::from("two") => 2 });
-}
-
-#[test]
-fn serialize_maps_with_various_types() {
-    let result =
-        to_attribute_value(hashmap! { 1 => String::from("1"), 2 => String::from("2") }).unwrap();
-
-    assert_eq!(
-        result,
-        AttributeValue {
-            m: Some(hashmap! {
-                String::from("1") => AttributeValue {
-                    s: Some(String::from("1")),
-                    ..AttributeValue::default()
-                },
-                String::from("2") => AttributeValue {
-                    s: Some(String::from("2")),
-                    ..AttributeValue::default()
-                },
-            }),
-            ..AttributeValue::default()
-        },
-    );
-
-    assert_identical_json!(hashmap! { 1 => String::from("1"), 2 => String::from("2") });
-
-    macro_rules! test_map {
-        ($($expr:expr),*) => {
-            assert_identical_json_with_error!(hashmap! {
-                $(
-                    $expr => String::from(stringify!($expr)),
-                )*
-            })
-        }
-    }
-
-    test_map!(1_u8, 2_u8);
-    test_map!(-1_i8, -2_i8);
-    test_map!('a', 'b');
-
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-    struct Struct(i64);
-    test_map!(Struct(1), Struct(2));
-
+    /// Assert that the expression is the same whether it is serialized directly, or serialized
+    /// first to json and then to an attribute value
+    fn assert_identical_json<T>(t1: T, t2: T)
+    where
+        T: Serialize,
     {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-        /// Externally tagged
-        enum VariantType {
-            Unit,
-            Newtype(String),
-            Struct { value: String },
-            Tuple(String, String),
-        }
-
-        test_map!(VariantType::Unit);
-        test_map!(VariantType::Newtype(String::from("one")));
-        test_map!(VariantType::Struct {
-            value: String::from("one")
-        });
-        test_map!(VariantType::Tuple(String::from("one"), String::from("two")));
+        let direct_result = to_attribute_value(t1).unwrap();
+        let indirect_result = to_attribute_value(serde_json::to_value(t2).unwrap()).unwrap();
+        assert_eq!(direct_result, indirect_result);
     }
 
+    macro_rules! assert_identical_json_with_error {
+        ($expr:expr) => {
+            assert_identical_json_with_error($expr, $expr);
+        };
+    }
+
+    fn assert_identical_json_with_error<T>(t1: T, t2: T)
+    where
+        T: Serialize,
     {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-        #[serde(tag = "type")]
-        /// Internally tagged
-        enum VariantType {
+        let direct_result = to_attribute_value(t1);
+        let json_result = serde_json::to_value(t2);
+
+        match (direct_result, json_result) {
+            (Ok(direct_result), Ok(json_result)) => match to_attribute_value(json_result) {
+                Ok(indirect_result) => assert_eq!(direct_result, indirect_result),
+                Err(_) => panic!("dynamo, json succeeded, indirect failed"),
+            },
+            (Ok(_), Err(_)) => panic!("dynamo succeeded, json failed"),
+            (Err(_), Ok(_)) => panic!("dynamo failed, json succeeded"),
+            (Err(_), Err(_)) => { /* Both failing is OK. */ }
+        }
+    }
+
+    #[test]
+    fn serialize_string() {
+        let result = to_attribute_value(String::from("Value")).unwrap();
+        assert_eq!(
+            result,
+            AttributeValue {
+                s: Some(String::from("Value")),
+                ..AttributeValue::default()
+            }
+        );
+        assert_identical_json!(String::from("Value"));
+    }
+
+    #[test]
+    fn serialize_num() {
+        macro_rules! serialize_num {
+            ($ty:ty, $n:expr) => {{
+                let v: $ty = $n;
+                let result = to_attribute_value(v).unwrap();
+                assert_eq!(
+                    result,
+                    AttributeValue {
+                        n: Some(String::from(stringify!($n))),
+                        ..AttributeValue::default()
+                    }
+                );
+            }};
+        }
+
+        serialize_num!(i8, -1);
+        serialize_num!(u8, 1);
+        serialize_num!(i16, -1);
+        serialize_num!(u16, 1);
+        serialize_num!(i32, -1);
+        serialize_num!(u32, 1);
+        serialize_num!(i64, -1);
+        serialize_num!(u64, 1);
+        serialize_num!(f32, 1.1);
+        serialize_num!(f64, 1.1);
+    }
+
+    #[test]
+    fn serialize_bool() {
+        let result = to_attribute_value(true).unwrap();
+        assert_eq!(
+            result,
+            AttributeValue {
+                bool: Some(true),
+                ..AttributeValue::default()
+            }
+        );
+        assert_identical_json!(true);
+    }
+
+    #[test]
+    fn serialize_char() {
+        let result = to_attribute_value('🥳').unwrap();
+        assert_eq!(
+            result,
+            AttributeValue {
+                s: Some(String::from("🥳")),
+                ..AttributeValue::default()
+            }
+        );
+        assert_identical_json!('🥳');
+    }
+
+    #[test]
+    fn serialize_unit() {
+        let result = to_attribute_value(()).unwrap();
+        assert_eq!(
+            result,
+            AttributeValue {
+                null: Some(true),
+                ..AttributeValue::default()
+            }
+        );
+        assert_identical_json!(());
+    }
+
+    #[test]
+    fn serialize_option() {
+        let result = to_attribute_value(Some(1_u8)).unwrap();
+        assert_eq!(
+            result,
+            AttributeValue {
+                n: Some(String::from("1")),
+                ..AttributeValue::default()
+            }
+        );
+        assert_identical_json!(Some(1_u8));
+
+        let result = to_attribute_value(Option::<u8>::None).unwrap();
+        assert_eq!(
+            result,
+            AttributeValue {
+                null: Some(true),
+                ..AttributeValue::default()
+            }
+        );
+        assert_identical_json!(Option::<u8>::None);
+    }
+
+    #[test]
+    fn serialize_struct() {
+        #[derive(Clone, Serialize, Deserialize)]
+        struct Subject {
+            value: String,
+        }
+
+        let source = Subject {
+            value: String::from("Value"),
+        };
+
+        let result = to_item(source.clone()).unwrap();
+        assert_eq!(
+            result,
+            hashmap! {
+                String::from("value") => AttributeValue { s: Some(String::from("Value")), ..AttributeValue::default() },
+            }
+        );
+        assert_identical_json!(source.clone());
+    }
+
+    #[test]
+    fn serialize_bytes() {
+        #[derive(Clone, Serialize, Deserialize)]
+        struct Subject {
+            #[serde(with = "serde_bytes")]
+            value: Vec<u8>,
+        }
+
+        let source = Subject {
+            value: vec![116, 101, 115, 116, 0, 0, 0, 0],
+        };
+
+        let result = to_item(source.clone()).unwrap();
+        assert_eq!(
+            result,
+            hashmap! {
+                String::from("value") => AttributeValue { b: Some(vec![116, 101, 115, 116, 0, 0, 0, 0].into()), ..AttributeValue::default() },
+            }
+        );
+    }
+
+    #[test]
+    fn serialize_array_of_structs() {
+        #[derive(Clone, Serialize, Deserialize)]
+        struct Subject {
+            value: String,
+        }
+
+        let mut source = Vec::new();
+        for i in 1..=3 {
+            let s = Subject {
+                value: i.to_string(),
+            };
+            source.push(s);
+        }
+
+        let result = to_attribute_value(source.clone()).unwrap();
+        assert_eq!(
+            result,
+            AttributeValue {
+                l: Some(vec![
+                    AttributeValue {
+                        m: Some(hashmap! {
+                            String::from("value") => AttributeValue { s: Some(String::from("1")), ..AttributeValue::default() },
+                        }),
+                        ..AttributeValue::default()
+                    },
+                    AttributeValue {
+                        m: Some(hashmap! {
+                            String::from("value") => AttributeValue { s: Some(String::from("2")), ..AttributeValue::default() },
+                        }),
+                        ..AttributeValue::default()
+                    },
+                    AttributeValue {
+                        m: Some(hashmap! {
+                            String::from("value") => AttributeValue { s: Some(String::from("3")), ..AttributeValue::default() },
+                        }),
+                        ..AttributeValue::default()
+                    },
+                ]),
+                ..AttributeValue::default()
+            },
+        );
+        assert_identical_json!(source.clone());
+    }
+
+    #[test]
+    fn serialize_unit_struct() {
+        #[derive(Serialize, Deserialize)]
+        struct Subject;
+
+        let result = to_attribute_value(Subject).unwrap();
+        assert_eq!(
+            result,
+            AttributeValue {
+                null: Some(true),
+                ..AttributeValue::default()
+            }
+        );
+
+        assert_identical_json!(Subject);
+    }
+
+    #[test]
+    fn serialize_newtype_struct() {
+        #[derive(Serialize, Deserialize)]
+        struct Subject(String);
+
+        let result = to_attribute_value(Subject(String::from("one"))).unwrap();
+        assert_eq!(
+            result,
+            AttributeValue {
+                s: Some(String::from("one")),
+                ..AttributeValue::default()
+            }
+        );
+
+        assert_identical_json!(Subject(String::from("one")));
+    }
+
+    #[test]
+    fn serialize_tuple_struct() {
+        #[derive(Serialize, Deserialize)]
+        struct Subject(String, String);
+
+        let result = to_attribute_value(Subject(String::from("one"), String::from("two"))).unwrap();
+        assert_eq!(
+            result,
+            AttributeValue {
+                l: Some(vec![
+                    AttributeValue {
+                        s: Some(String::from("one")),
+                        ..AttributeValue::default()
+                    },
+                    AttributeValue {
+                        s: Some(String::from("two")),
+                        ..AttributeValue::default()
+                    },
+                ]),
+                ..AttributeValue::default()
+            }
+        );
+
+        assert_identical_json!(Subject(String::from("one"), String::from("two")));
+    }
+
+    #[test]
+    fn serialize_tuple() {
+        let result = to_attribute_value((String::from("one"), String::from("two"))).unwrap();
+        assert_eq!(
+            result,
+            AttributeValue {
+                l: Some(vec![
+                    AttributeValue {
+                        s: Some(String::from("one")),
+                        ..AttributeValue::default()
+                    },
+                    AttributeValue {
+                        s: Some(String::from("two")),
+                        ..AttributeValue::default()
+                    },
+                ]),
+                ..AttributeValue::default()
+            }
+        );
+
+        assert_identical_json!((String::from("one"), String::from("two")));
+    }
+
+    #[test]
+    fn serialize_map_with_strings() {
+        let result =
+            to_attribute_value(hashmap! { String::from("one") => 1, String::from("two") => 2 })
+                .unwrap();
+
+        assert_eq!(
+            result,
+            AttributeValue {
+                m: Some(hashmap! {
+                    String::from("one") => AttributeValue {
+                        n: Some(String::from("1")),
+                        ..AttributeValue::default()
+                    },
+                    String::from("two") => AttributeValue {
+                        n: Some(String::from("2")),
+                        ..AttributeValue::default()
+                    },
+                }),
+                ..AttributeValue::default()
+            },
+        );
+
+        assert_identical_json!(hashmap! { String::from("one") => 1, String::from("two") => 2 });
+    }
+
+    #[test]
+    fn serialize_maps_with_various_types() {
+        let result =
+            to_attribute_value(hashmap! { 1 => String::from("1"), 2 => String::from("2") })
+                .unwrap();
+
+        assert_eq!(
+            result,
+            AttributeValue {
+                m: Some(hashmap! {
+                    String::from("1") => AttributeValue {
+                        s: Some(String::from("1")),
+                        ..AttributeValue::default()
+                    },
+                    String::from("2") => AttributeValue {
+                        s: Some(String::from("2")),
+                        ..AttributeValue::default()
+                    },
+                }),
+                ..AttributeValue::default()
+            },
+        );
+
+        assert_identical_json!(hashmap! { 1 => String::from("1"), 2 => String::from("2") });
+
+        macro_rules! test_map {
+            ($($expr:expr),*) => {
+                assert_identical_json_with_error!(hashmap! {
+                    $(
+                        $expr => String::from(stringify!($expr)),
+                    )*
+                })
+            }
+        }
+
+        test_map!(1_u8, 2_u8);
+        test_map!(-1_i8, -2_i8);
+        test_map!('a', 'b');
+
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+        struct Struct(i64);
+        test_map!(Struct(1), Struct(2));
+
+        {
+            #[derive(
+                Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+            )]
+            /// Externally tagged
+            enum VariantType {
+                Unit,
+                Newtype(String),
+                Struct { value: String },
+                Tuple(String, String),
+            }
+
+            test_map!(VariantType::Unit);
+            test_map!(VariantType::Newtype(String::from("one")));
+            test_map!(VariantType::Struct {
+                value: String::from("one")
+            });
+            test_map!(VariantType::Tuple(String::from("one"), String::from("two")));
+        }
+
+        {
+            #[derive(
+                Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+            )]
+            #[serde(tag = "type")]
+            /// Internally tagged
+            enum VariantType {
+                Unit,
+                Newtype(String),
+                Struct { value: String },
+            }
+
+            test_map!(VariantType::Unit);
+            test_map!(VariantType::Newtype(String::from("one")));
+            test_map!(VariantType::Struct {
+                value: String::from("one")
+            });
+        }
+
+        {
+            #[derive(
+                Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+            )]
+            #[serde(tag = "type", content = "content")]
+            /// Adjacently tagged
+            enum VariantType {
+                Unit,
+                Newtype(String),
+                Struct { value: String },
+                Tuple(String, String),
+            }
+
+            test_map!(VariantType::Unit);
+            test_map!(VariantType::Newtype(String::from("one")));
+            test_map!(VariantType::Struct {
+                value: String::from("one")
+            });
+            test_map!(VariantType::Tuple(String::from("one"), String::from("two")));
+        }
+
+        {
+            #[derive(
+                Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+            )]
+            #[serde(untagged)]
+            /// Untagged
+            enum VariantType {
+                Unit,
+                Newtype(String),
+                Struct { value: String },
+                Tuple(String, String),
+            }
+
+            test_map!(VariantType::Unit);
+            test_map!(VariantType::Newtype(String::from("one")));
+            test_map!(VariantType::Struct {
+                value: String::from("one")
+            });
+            test_map!(VariantType::Tuple(String::from("one"), String::from("two")));
+        }
+    }
+
+    #[test]
+    fn serialize_enum_unit() {
+        #[derive(Serialize, Deserialize)]
+        enum Subject {
             Unit,
-            Newtype(String),
-            Struct { value: String },
         }
 
-        test_map!(VariantType::Unit);
-        test_map!(VariantType::Newtype(String::from("one")));
-        test_map!(VariantType::Struct {
-            value: String::from("one")
-        });
+        let result = to_attribute_value(Subject::Unit).unwrap();
+        assert_eq!(
+            result,
+            AttributeValue {
+                s: Some(String::from("Unit")),
+                ..AttributeValue::default()
+            }
+        );
+
+        assert_identical_json!(Subject::Unit);
     }
 
-    {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-        #[serde(tag = "type", content = "content")]
-        /// Adjacently tagged
-        enum VariantType {
-            Unit,
-            Newtype(String),
-            Struct { value: String },
-            Tuple(String, String),
+    #[test]
+    fn serialize_enum_newtype() {
+        #[derive(Serialize, Deserialize)]
+        enum Subject {
+            Newtype(u8),
         }
 
-        test_map!(VariantType::Unit);
-        test_map!(VariantType::Newtype(String::from("one")));
-        test_map!(VariantType::Struct {
-            value: String::from("one")
-        });
-        test_map!(VariantType::Tuple(String::from("one"), String::from("two")));
+        let result = to_attribute_value(Subject::Newtype(1)).unwrap();
+        assert_eq!(
+            result,
+            AttributeValue {
+                m: Some(hashmap! {
+                    String::from("Newtype") => AttributeValue {
+                        n: Some(String::from("1")),
+                        ..AttributeValue::default()
+                    },
+                }),
+                ..AttributeValue::default()
+            }
+        );
+
+        assert_identical_json!(Subject::Newtype(1));
     }
 
-    {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-        #[serde(untagged)]
-        /// Untagged
-        enum VariantType {
-            Unit,
-            Newtype(String),
-            Struct { value: String },
-            Tuple(String, String),
+    #[test]
+    fn serialize_enum_tuple() {
+        #[derive(Serialize, Deserialize)]
+        enum Subject {
+            Tuple(u8, u8),
         }
 
-        test_map!(VariantType::Unit);
-        test_map!(VariantType::Newtype(String::from("one")));
-        test_map!(VariantType::Struct {
-            value: String::from("one")
-        });
-        test_map!(VariantType::Tuple(String::from("one"), String::from("two")));
-    }
-}
+        let result = to_attribute_value(Subject::Tuple(1, 2)).unwrap();
 
-#[test]
-fn serialize_enum_unit() {
-    #[derive(Serialize, Deserialize)]
-    enum Subject {
-        Unit,
+        assert_eq!(
+            result,
+            AttributeValue {
+                m: Some(hashmap! {
+                    String::from("Tuple") => AttributeValue {
+                        l: Some(vec![
+                            AttributeValue {
+                                n: Some(String::from("1")),
+                                ..AttributeValue::default()
+                            },
+                            AttributeValue {
+                                n: Some(String::from("2")),
+                                ..AttributeValue::default()
+                            },
+                        ]),
+                        ..AttributeValue::default()
+                    },
+                }),
+                ..AttributeValue::default()
+            }
+        );
+
+        assert_identical_json!(Subject::Tuple(1, 2));
     }
 
-    let result = to_attribute_value(Subject::Unit).unwrap();
-    assert_eq!(
-        result,
-        AttributeValue {
-            s: Some(String::from("Unit")),
-            ..AttributeValue::default()
+    #[test]
+    fn serialize_enum_struct_variant() {
+        #[derive(Serialize, Deserialize)]
+        enum Subject {
+            Structy { one: u8, two: u8 },
         }
-    );
 
-    assert_identical_json!(Subject::Unit);
-}
+        let result = to_attribute_value(Subject::Structy { one: 1, two: 2 }).unwrap();
 
-#[test]
-fn serialize_enum_newtype() {
-    #[derive(Serialize, Deserialize)]
-    enum Subject {
-        Newtype(u8),
+        assert_eq!(
+            result,
+            AttributeValue {
+                m: Some(hashmap! {
+                    String::from("Structy") => AttributeValue {
+                        m: Some(hashmap! {
+                            String::from("one") => AttributeValue {
+                                n: Some(String::from("1")),
+                                ..AttributeValue::default()
+                            },
+                            String::from("two") => AttributeValue {
+                                n: Some(String::from("2")),
+                                ..AttributeValue::default()
+                            },
+                        }),
+                        ..AttributeValue::default()
+                    },
+                }),
+                ..AttributeValue::default()
+            }
+        );
+
+        assert_identical_json!(Subject::Structy { one: 1, two: 2 });
     }
 
-    let result = to_attribute_value(Subject::Newtype(1)).unwrap();
-    assert_eq!(
-        result,
-        AttributeValue {
-            m: Some(hashmap! {
-                String::from("Newtype") => AttributeValue {
-                    n: Some(String::from("1")),
-                    ..AttributeValue::default()
-                },
-            }),
-            ..AttributeValue::default()
+    #[test]
+    fn internally_tagged_enum() {
+        #[derive(Serialize)]
+        #[serde(tag = "type", rename_all = "snake_case")]
+        enum Enum {
+            One { one: u8 },
+            Two { one: u8, two: u8 },
         }
-    );
 
-    assert_identical_json!(Subject::Newtype(1));
-}
+        let result = to_attribute_value(Enum::Two { one: 1, two: 2 }).unwrap();
 
-#[test]
-fn serialize_enum_tuple() {
-    #[derive(Serialize, Deserialize)]
-    enum Subject {
-        Tuple(u8, u8),
+        assert_eq!(
+            result,
+            AttributeValue {
+                m: Some(hashmap! {
+                    String::from("type") => AttributeValue {
+                        s: Some(String::from("two")),
+                        ..AttributeValue::default()
+                    },
+                    String::from("one") => AttributeValue {
+                        n: Some(String::from("1")),
+                        ..AttributeValue::default()
+                    },
+                    String::from("two") => AttributeValue {
+                        n: Some(String::from("2")),
+                        ..AttributeValue::default()
+                    },
+                }),
+                ..AttributeValue::default()
+            }
+        );
+
+        assert_identical_json!(Enum::One { one: 1 });
+        assert_identical_json!(Enum::Two { one: 1, two: 2 });
     }
-
-    let result = to_attribute_value(Subject::Tuple(1, 2)).unwrap();
-
-    assert_eq!(
-        result,
-        AttributeValue {
-            m: Some(hashmap! {
-                String::from("Tuple") => AttributeValue {
-                    l: Some(vec![
-                        AttributeValue {
-                            n: Some(String::from("1")),
-                            ..AttributeValue::default()
-                        },
-                        AttributeValue {
-                            n: Some(String::from("2")),
-                            ..AttributeValue::default()
-                        },
-                    ]),
-                    ..AttributeValue::default()
-                },
-            }),
-            ..AttributeValue::default()
-        }
-    );
-
-    assert_identical_json!(Subject::Tuple(1, 2));
-}
-
-#[test]
-fn serialize_enum_struct_variant() {
-    #[derive(Serialize, Deserialize)]
-    enum Subject {
-        Structy { one: u8, two: u8 },
-    }
-
-    let result = to_attribute_value(Subject::Structy { one: 1, two: 2 }).unwrap();
-
-    assert_eq!(
-        result,
-        AttributeValue {
-            m: Some(hashmap! {
-                String::from("Structy") => AttributeValue {
-                    m: Some(hashmap! {
-                        String::from("one") => AttributeValue {
-                            n: Some(String::from("1")),
-                            ..AttributeValue::default()
-                        },
-                        String::from("two") => AttributeValue {
-                            n: Some(String::from("2")),
-                            ..AttributeValue::default()
-                        },
-                    }),
-                    ..AttributeValue::default()
-                },
-            }),
-            ..AttributeValue::default()
-        }
-    );
-
-    assert_identical_json!(Subject::Structy { one: 1, two: 2 });
-}
-
-#[test]
-fn internally_tagged_enum() {
-    #[derive(Serialize)]
-    #[serde(tag = "type", rename_all = "snake_case")]
-    enum Enum {
-        One { one: u8 },
-        Two { one: u8, two: u8 },
-    }
-
-    let result = to_attribute_value(Enum::Two { one: 1, two: 2 }).unwrap();
-
-    assert_eq!(
-        result,
-        AttributeValue {
-            m: Some(hashmap! {
-                String::from("type") => AttributeValue {
-                    s: Some(String::from("two")),
-                    ..AttributeValue::default()
-                },
-                String::from("one") => AttributeValue {
-                    n: Some(String::from("1")),
-                    ..AttributeValue::default()
-                },
-                String::from("two") => AttributeValue {
-                    n: Some(String::from("2")),
-                    ..AttributeValue::default()
-                },
-            }),
-            ..AttributeValue::default()
-        }
-    );
-
-    assert_identical_json!(Enum::One { one: 1 });
-    assert_identical_json!(Enum::Two { one: 1, two: 2 });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,9 +331,10 @@ mod error;
 // mod ser;
 
 pub use error::{Error, Result};
-
+#[cfg(feature = "aws_sdk")]
 pub mod aws_sdk_dynamodb;
 pub mod generic;
+#[cfg(feature = "rusoto")]
 pub mod rusoto_dynamodb;
 
 // use error::ErrorImpl;


### PR DESCRIPTION
#### Note: (there aren't actually 1200 edits, I just moved the items in the generic test.rs files into a feature flag "rusoto" block 😆 

👋  Thanks for this alpha branch that lets us use aws_sdk!

I wanted to try and avoid using Rusoto as a dependency entirely, so I made some quick changes to accelerate that forward.

- Enable feature flags for rusoto & aws_sdk
- rusoto is the default feature, but is optional
- aws_sdk is an optional feature, not included by default
- added a couple doctests building off your example [here for scan()](https://github.com/zenlist/serde_dynamo/issues/9#issuecomment-836803967) and this [example I found for get_item()](https://github.com/fstar-dev/aws-dynamoDB-exam/blob/0b8dba56d6629d7c471450ab597a4d27c47cda07/DynamoDB-SDK-Examples/rust/working_with_items/src/get-item/main.rs) when I was struggling to figure out how to use the aws_sdk. 

The largest thing I changed was just putting all the `generic` serialize and deserialize tests behind the `rusoto` flag as a temporary fix for now.

To prevent a breaking change with anyone using the `3.0.0-alpha.0` branch as a dependency, perhaps we might want to move this to a new branch `alpha.1`