### PR TITLE
Update AWS SDK dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["serde", "rusoto", "dynamodb", "dynamo", "serde_dynamodb"]
 
 [dependencies]
 rusoto_dynamodb = { version = "0.47", default-features = false, optional = true }
-aws-sdk-dynamodb = { git = "https://github.com/awslabs/aws-sdk-rust", branch = "main", optional = true }
+aws-sdk-dynamodb = { version = "0.0.25-alpha", optional = true }
 serde = "1"
 
 [dev-dependencies]

--- a/src/generic/de/tests.rs
+++ b/src/generic/de/tests.rs
@@ -11,7 +11,7 @@ mod tests {
 
     macro_rules! assert_identical_json {
         ($ty:ty, $expr:expr) => {
-            assert_identical_json::<$ty>($expr, $expr);
+            assert_identical_json::<$ty>($expr, $expr)
         };
     }
     /// Assert that the expression is the same whether it is deserialized directly, or deserialized


### PR DESCRIPTION
Update dependency on AWS SDK to the package published on crates.io.

This PR also includes a fix for <https://github.com/rust-lang/rust/issues/79813>, not sure if it deserves a separate PR.

All tests passed on rustc 1.56.1 edition = "2021".