### PR TITLE
Update aws_sdk to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,6 @@ keywords = ["serde", "rusoto", "dynamodb", "dynamo", "serde_dynamodb"]
 
 [dependencies]
 aws_sdk_dynamodb_0_0_25_alpha = { package = "aws-sdk-dynamodb", version = "0.0.25-alpha", default-features = false, optional = true }
-aws_sdk_dynamodb_0_2 = { package = "aws-sdk-dynamodb", version = "0.2", default-features = false, optional = true }
-aws_sdk_dynamodb_0_3 = { package = "aws-sdk-dynamodb", version = "0.3", default-features = false, optional = true }
-aws_sdk_dynamodb_0_4 = { package = "aws-sdk-dynamodb", version = "0.4", default-features = false, optional = true }
-aws_sdk_dynamodb_0_5 = { package = "aws-sdk-dynamodb", version = "0.5", default-features = false, optional = true }
 aws_sdk_dynamodb_0_6 = { package = "aws-sdk-dynamodb", version = "0.6", default-features = false, optional = true }
 aws_sdk_dynamodb_0_7 = { package = "aws-sdk-dynamodb", version = "0.7", default-features = false, optional = true }
 aws_sdk_dynamodb_0_8 = { package = "aws-sdk-dynamodb", version = "0.8", default-features = false, optional = true }
@@ -31,10 +27,6 @@ rusoto_core_0_47_crate = { package = "rusoto_core", version = "0.47", default-fe
 
 [features]
 "aws-sdk-dynamodb+0_0_25-alpha" = ["aws_sdk_dynamodb_0_0_25_alpha"]
-"aws-sdk-dynamodb+0_2" = ["aws_sdk_dynamodb_0_2"]
-"aws-sdk-dynamodb+0_3" = ["aws_sdk_dynamodb_0_3"]
-"aws-sdk-dynamodb+0_4" = ["aws_sdk_dynamodb_0_4"]
-"aws-sdk-dynamodb+0_5" = ["aws_sdk_dynamodb_0_5"]
 "aws-sdk-dynamodb+0_6" = ["aws_sdk_dynamodb_0_6"]
 "aws-sdk-dynamodb+0_7" = ["aws_sdk_dynamodb_0_7"]
 "aws-sdk-dynamodb+0_8" = ["aws_sdk_dynamodb_0_8"]
@@ -43,7 +35,7 @@ rusoto_core_0_47_crate = { package = "rusoto_core", version = "0.47", default-fe
 "rusoto_dynamodbstreams+0_46" = ["rusoto_dynamodbstreams_0_46"]
 "rusoto_dynamodbstreams+0_47" = ["rusoto_dynamodbstreams_0_47"]
 
-__doc = ["rusoto_core_0_46_crate", "rusoto_core_0_47_crate", "aws_sdk_dynamodb_0_0_25_alpha/client", "aws_sdk_dynamodb_0_2/client", "aws_sdk_dynamodb_0_3", "aws_sdk_dynamodb_0_4", "aws-sdk-dynamodb+0_5", "aws-sdk-dynamodb+0_6", "aws-sdk-dynamodb+0_7", "aws-sdk-dynamodb+0_8"]
+__doc = ["rusoto_core_0_46_crate", "rusoto_core_0_47_crate", "aws_sdk_dynamodb_0_0_25_alpha/client", "aws-sdk-dynamodb+0_6", "aws-sdk-dynamodb+0_7", "aws-sdk-dynamodb+0_8"]
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_dynamo"
-version = "3.0.0-alpha.5"
+version = "3.0.0-alpha.6"
 authors = ["Bryan Burgers <bryan@burgers.io>"]
 edition = "2021"
 license = "MIT"
@@ -19,6 +19,7 @@ aws_sdk_dynamodb_0_4 = { package = "aws-sdk-dynamodb", version = "0.4", default-
 aws_sdk_dynamodb_0_5 = { package = "aws-sdk-dynamodb", version = "0.5", default-features = false, optional = true }
 aws_sdk_dynamodb_0_6 = { package = "aws-sdk-dynamodb", version = "0.6", default-features = false, optional = true }
 aws_sdk_dynamodb_0_7 = { package = "aws-sdk-dynamodb", version = "0.7", default-features = false, optional = true }
+aws_sdk_dynamodb_0_8 = { package = "aws-sdk-dynamodb", version = "0.8", default-features = false, optional = true }
 rusoto_dynamodb_0_46 = { package = "rusoto_dynamodb", version = "0.46", default-features = false, optional = true }
 rusoto_dynamodb_0_47 = { package = "rusoto_dynamodb", version = "0.47", default-features = false, optional = true }
 rusoto_dynamodbstreams_0_46 = { package = "rusoto_dynamodbstreams", version = "0.46", default-features = false, optional = true }
@@ -36,12 +37,13 @@ rusoto_core_0_47_crate = { package = "rusoto_core", version = "0.47", default-fe
 "aws-sdk-dynamodb+0_5" = ["aws_sdk_dynamodb_0_5"]
 "aws-sdk-dynamodb+0_6" = ["aws_sdk_dynamodb_0_6"]
 "aws-sdk-dynamodb+0_7" = ["aws_sdk_dynamodb_0_7"]
+"aws-sdk-dynamodb+0_8" = ["aws_sdk_dynamodb_0_8"]
 "rusoto_dynamodb+0_46" = ["rusoto_dynamodb_0_46"]
 "rusoto_dynamodb+0_47" = ["rusoto_dynamodb_0_47"]
 "rusoto_dynamodbstreams+0_46" = ["rusoto_dynamodbstreams_0_46"]
 "rusoto_dynamodbstreams+0_47" = ["rusoto_dynamodbstreams_0_47"]
 
-__doc = ["rusoto_core_0_46_crate", "rusoto_core_0_47_crate", "aws_sdk_dynamodb_0_0_25_alpha/client", "aws_sdk_dynamodb_0_2/client", "aws_sdk_dynamodb_0_3", "aws_sdk_dynamodb_0_4", "aws-sdk-dynamodb+0_5", "aws-sdk-dynamodb+0_6", "aws-sdk-dynamodb+0_7"]
+__doc = ["rusoto_core_0_46_crate", "rusoto_core_0_47_crate", "aws_sdk_dynamodb_0_0_25_alpha/client", "aws_sdk_dynamodb_0_2/client", "aws_sdk_dynamodb_0_3", "aws_sdk_dynamodb_0_4", "aws-sdk-dynamodb+0_5", "aws-sdk-dynamodb+0_6", "aws-sdk-dynamodb+0_7", "aws-sdk-dynamodb+0_8"]
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,10 +102,10 @@
 //!
 //! ```toml
 //! [dependencies]
-//! serde_dynamo = { version = "3", features = ["aws-sdk-dynamodb+0_7"] }
+//! serde_dynamo = { version = "3", features = ["aws-sdk-dynamodb+0_8"] }
 //! ```
 //!
-//! See [`aws_sdk_dynamodb_0_7`] for examples and more information.
+//! See [`aws_sdk_dynamodb_0_8`] for examples and more information.
 //!
 //!
 //! ## rusoto support
@@ -266,6 +266,13 @@ aws_sdk_macro!(
     crate_name = aws_sdk_dynamodb_0_7,
     aws_version = "0.7",
     blob_path = ::aws_sdk_dynamodb_0_7::types::Blob,
+);
+
+aws_sdk_macro!(
+    feature = "aws-sdk-dynamodb+0_8",
+    crate_name = aws_sdk_dynamodb_0_8,
+    aws_version = "0.8",
+    blob_path = ::aws_sdk_dynamodb_0_8::types::Blob,
 );
 
 rusoto_macro!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,34 +227,6 @@ aws_sdk_macro!(
 );
 
 aws_sdk_macro!(
-    feature = "aws-sdk-dynamodb+0_2",
-    crate_name = aws_sdk_dynamodb_0_2,
-    aws_version = "0.2",
-    blob_path = ::aws_sdk_dynamodb_0_2::Blob,
-);
-
-aws_sdk_macro!(
-    feature = "aws-sdk-dynamodb+0_3",
-    crate_name = aws_sdk_dynamodb_0_3,
-    aws_version = "0.3",
-    blob_path = ::aws_sdk_dynamodb_0_3::Blob,
-);
-
-aws_sdk_macro!(
-    feature = "aws-sdk-dynamodb+0_4",
-    crate_name = aws_sdk_dynamodb_0_4,
-    aws_version = "0.4",
-    blob_path = ::aws_sdk_dynamodb_0_4::Blob,
-);
-
-aws_sdk_macro!(
-    feature = "aws-sdk-dynamodb+0_5",
-    crate_name = aws_sdk_dynamodb_0_5,
-    aws_version = "0.5",
-    blob_path = ::aws_sdk_dynamodb_0_5::Blob,
-);
-
-aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_6",
     crate_name = aws_sdk_dynamodb_0_6,
     aws_version = "0.6",


### PR DESCRIPTION
I've included a separate commit dropping aws_sdk versions before 0.6. I don't personally see any issues with dropping the old versions as they'll continue to work with older releases of this crate, otherwise I'm happy to revert if anyone objects to their removal.