### PR TITLE
Support for `aws_sdk_dynamodbstreams`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["serde", "rusoto", "dynamodb", "dynamo", "serde_dynamodb"]
 [dependencies]
 __aws_sdk_dynamodb_0_7 = { package = "aws-sdk-dynamodb", version = "0.7", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_8 = { package = "aws-sdk-dynamodb", version = "0.8", default-features = false, optional = true }
+__aws_sdk_dynamodbstreams_0_8 = { package = "aws-sdk-dynamodbstreams", version = "0.8", default-features = false, optional = true }
 __rusoto_dynamodb_0_46 = { package = "rusoto_dynamodb", version = "0.46", default-features = false, optional = true }
 __rusoto_dynamodb_0_47 = { package = "rusoto_dynamodb", version = "0.47", default-features = false, optional = true }
 __rusoto_dynamodbstreams_0_46 = { package = "rusoto_dynamodbstreams", version = "0.46", default-features = false, optional = true }
@@ -26,12 +27,13 @@ __rusoto_core_0_47_crate = { package = "rusoto_core", version = "0.47", default-
 [features]
 "aws-sdk-dynamodb+0_7" = ["__aws_sdk_dynamodb_0_7"]
 "aws-sdk-dynamodb+0_8" = ["__aws_sdk_dynamodb_0_8"]
+"aws-sdk-dynamodbstreams+0_8" = ["__aws_sdk_dynamodbstreams_0_8"]
 "rusoto_dynamodb+0_46" = ["__rusoto_dynamodb_0_46"]
 "rusoto_dynamodb+0_47" = ["__rusoto_dynamodb_0_47"]
 "rusoto_dynamodbstreams+0_46" = ["__rusoto_dynamodbstreams_0_46"]
 "rusoto_dynamodbstreams+0_47" = ["__rusoto_dynamodbstreams_0_47"]
 
-__doc = ["__rusoto_core_0_46_crate", "__rusoto_core_0_47_crate", "aws-sdk-dynamodb+0_7", "aws-sdk-dynamodb+0_8"]
+__doc = ["__rusoto_core_0_46_crate", "__rusoto_core_0_47_crate", "aws-sdk-dynamodb+0_7", "aws-sdk-dynamodb+0_8", "aws-sdk-dynamodbstreams+0_8"]
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,18 @@
 //! See [`__aws_sdk_dynamodb_0_8`] for examples and more information.
 //!
 //!
+//! **serde_dynamo** works well with [aws-sdk-dynamodbstreams].
+//!
+//! Add the following to your dependencies.
+//!
+//! ```toml
+//! [dependencies]
+//! serde_dynamo = { version = "3", features = ["aws-sdk-dynamodbstreams+0_8"] }
+//! ```
+//!
+//! See [`__aws_sdk_dynamodbstreams_0_8`] for examples and more information.
+//!
+//!
 //! ## rusoto support
 //!
 //! **serde_dynamo** works well with [rusoto_dynamodb].
@@ -203,6 +215,7 @@
 //! [adjacently tagged enums]: https://serde.rs/enum-representations.html#adjacently-tagged
 //! [untagged enums]: https://serde.rs/enum-representations.html#untagged
 //! [aws-sdk-dynamodb]: https://docs.rs/aws-sdk-dynamodb
+//! [aws-sdk-dynamodbstreams]: https://docs.rs/aws-sdk-dynamodbstreams
 //! [rusoto_dynamodb]: https://docs.rs/rusoto_dynamodb
 
 mod attribute_value;
@@ -215,7 +228,7 @@ mod test_attribute_value;
 pub use attribute_value::AttributeValue;
 pub use de::{from_attribute_value, from_item, from_items, Deserializer};
 pub use error::{Error, Result};
-use macros::{aws_sdk_macro, rusoto_macro, rusoto_streams_macro};
+use macros::{aws_sdk_macro, aws_sdk_streams_macro, rusoto_macro, rusoto_streams_macro};
 pub use ser::{to_attribute_value, to_item, Serializer};
 pub use test_attribute_value::TestAttributeValue;
 
@@ -228,6 +241,12 @@ aws_sdk_macro!(
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_8",
     crate_name = __aws_sdk_dynamodb_0_8,
+    aws_version = "0.8",
+);
+
+aws_sdk_streams_macro!(
+    feature = "aws-sdk-dynamodbstreams+0_8",
+    crate_name = __aws_sdk_dynamodbstreams_0_8,
     aws_version = "0.8",
 );
 

--- a/src/macros/aws_sdk_streams.rs
+++ b/src/macros/aws_sdk_streams.rs
@@ -1,0 +1,326 @@
+macro_rules! aws_sdk_streams_macro {
+    (feature = $feature:literal, crate_name = $mod_name:ident, aws_version = $version:literal,) => {
+        #[cfg(feature = $feature)]
+        #[cfg_attr(docsrs, doc(cfg(feature = $feature)))]
+        pub mod $mod_name {
+            #![doc = concat!("Support for [aws-sdk-dynamodbstreams](https://docs.rs/aws-sdk-dynamodbstreams/", $version, ") version ", $version)]
+            //!
+            //! Because [aws-sdk-dynamodbstreams] has not yet reached version 1.0, a feature is required to
+            //! enable support. Add the following to your dependencies.
+            //!
+            //! ```toml
+            //! [dependencies]
+            #![doc = concat!("aws-sdk-dynamodbstreams = ", stringify!($version))]
+            #![doc = concat!("serde_dynamo = { version = \"3\", features = [", stringify!($feature), "] }")]
+            //! ```
+            //!
+            //! [aws-sdk-dynamodbstreams]: https://docs.rs/aws-sdk-dynamodbstreams
+            //! [aws_sdk_dynamodbstreams::model::AttributeValue]: https://docs.rs/rusoto_dynamodbstreams/0.47.0/rusoto_dynamodbstreams/struct.AttributeValue.html
+
+            use crate::Result;
+            use ::$mod_name::model::AttributeValue;
+            use std::collections::HashMap;
+
+            impl crate::AttributeValue for AttributeValue {
+                fn is_n(&self) -> bool {
+                    matches!(self, AttributeValue::N(..))
+                }
+
+                fn is_s(&self) -> bool {
+                    matches!(self, AttributeValue::S(..))
+                }
+
+                fn is_bool(&self) -> bool {
+                    matches!(self, AttributeValue::Bool(..))
+                }
+
+                fn is_b(&self) -> bool {
+                    matches!(self, AttributeValue::B(..))
+                }
+
+                fn is_null(&self) -> bool {
+                    matches!(self, AttributeValue::Null(..))
+                }
+
+                fn is_m(&self) -> bool {
+                    matches!(self, AttributeValue::M(..))
+                }
+
+                fn is_l(&self) -> bool {
+                    matches!(self, AttributeValue::L(..))
+                }
+
+                fn is_ss(&self) -> bool {
+                    matches!(self, AttributeValue::Ss(..))
+                }
+
+                fn is_ns(&self) -> bool {
+                    matches!(self, AttributeValue::Ns(..))
+                }
+
+                fn is_bs(&self) -> bool {
+                    matches!(self, AttributeValue::Bs(..))
+                }
+
+                fn as_n(&self) -> Option<&str> {
+                    if let AttributeValue::N(ref v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn as_s(&self) -> Option<&str> {
+                    if let AttributeValue::S(ref v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn as_bool(&self) -> Option<bool> {
+                    if let AttributeValue::Bool(v) = self {
+                        Some(*v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn as_b(&self) -> Option<&[u8]> {
+                    if let AttributeValue::B(ref v) = self {
+                        Some(v.as_ref())
+                    } else {
+                        None
+                    }
+                }
+
+                fn as_null(&self) -> Option<bool> {
+                    if let AttributeValue::Null(v) = self {
+                        Some(*v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn as_m(&self) -> Option<&HashMap<String, Self>> {
+                    if let AttributeValue::M(ref v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn as_l(&self) -> Option<&[Self]> {
+                    if let AttributeValue::L(ref v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn as_ss(&self) -> Option<&[String]> {
+                    if let AttributeValue::Ss(ref v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn as_ns(&self) -> Option<&[String]> {
+                    if let AttributeValue::Ns(ref v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn into_n(self) -> Option<String> {
+                    if let AttributeValue::N(v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn into_s(self) -> Option<String> {
+                    if let AttributeValue::S(v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn into_bool(self) -> Option<bool> {
+                    if let AttributeValue::Bool(v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn into_b(self) -> Option<Vec<u8>> {
+                    if let AttributeValue::B(v) = self {
+                        Some(v.into_inner())
+                    } else {
+                        None
+                    }
+                }
+
+                fn into_null(self) -> Option<bool> {
+                    if let AttributeValue::Null(v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn into_m(self) -> Option<HashMap<String, Self>> {
+                    if let AttributeValue::M(v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn into_l(self) -> Option<Vec<Self>> {
+                    if let AttributeValue::L(v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn into_ss(self) -> Option<Vec<String>> {
+                    if let AttributeValue::Ss(v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn into_ns(self) -> Option<Vec<String>> {
+                    if let AttributeValue::Ns(v) = self {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                }
+
+                fn into_bs(self) -> Option<Vec<Vec<u8>>> {
+                    if let AttributeValue::Bs(v) = self {
+                        Some(v.into_iter().map(|b| b.into_inner()).collect())
+                    } else {
+                        None
+                    }
+                }
+
+                fn construct_n(input: String) -> Self {
+                    AttributeValue::N(input)
+                }
+
+                fn construct_s(input: String) -> Self {
+                    AttributeValue::S(input)
+                }
+
+                fn construct_bool(input: bool) -> Self {
+                    AttributeValue::Bool(input)
+                }
+
+                fn construct_b(input: &[u8]) -> Self {
+                    AttributeValue::B($mod_name::types::Blob::new(input))
+                }
+
+                fn construct_null(input: bool) -> Self {
+                    AttributeValue::Null(input)
+                }
+
+                fn construct_m(input: HashMap<String, Self>) -> Self {
+                    AttributeValue::M(input)
+                }
+
+                fn construct_l(input: Vec<Self>) -> Self {
+                    AttributeValue::L(input)
+                }
+
+                fn construct_ss(input: Vec<String>) -> Self {
+                    AttributeValue::Ss(input)
+                }
+
+                fn construct_ns(input: Vec<String>) -> Self {
+                    AttributeValue::Ns(input)
+                }
+
+                fn construct_bs(input: Vec<Vec<u8>>) -> Self {
+                    let input = input.into_iter().map($mod_name::types::Blob::new).collect();
+                    AttributeValue::Bs(input)
+                }
+            }
+
+            /// A version of [`crate::to_attribute_value`] where the `Tout` generic is tied to
+            /// [`aws-sdk-dynamodbstreams::model::AttributeValue`](AttributeValue).
+            ///
+            /// Useful in very generic code where the type checker can't determine the type of
+            /// `Tout`.
+            pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>
+            where
+                T: serde::ser::Serialize,
+            {
+                crate::ser::to_attribute_value(value)
+            }
+
+            /// A version of [`crate::to_item`] where the `Tout` generic is tied to
+            /// [`aws-sdk-dynamodbstreams::model::AttributeValue`](AttributeValue).
+            ///
+            /// Useful in very generic code where the type checker can't determine the type of
+            /// `Tout`.
+            pub fn to_item<T>(value: T) -> Result<std::collections::HashMap<String, AttributeValue>>
+            where
+                T: serde::ser::Serialize,
+            {
+                crate::ser::to_item(value)
+            }
+
+            /// A version of [`crate::from_attribute_value`] where the `Tin` generic is tied to
+            /// [`aws-sdk-dynamodbstreams::model::AttributeValue`](AttributeValue).
+            ///
+            /// Useful in very generic code where the type checker can't determine the type of
+            /// `Tin`.
+            pub fn from_attribute_value<'a, T>(attribute_value: AttributeValue) -> Result<T>
+            where
+                T: serde::de::Deserialize<'a>,
+            {
+                crate::de::from_attribute_value(attribute_value)
+            }
+
+            /// A version of [`crate::from_item`] where the `Tin` generic is tied to
+            /// [`aws-sdk-dynamodbstreams::model::AttributeValue`](AttributeValue).
+            ///
+            /// Useful in very generic code where the type checker can't determine the type of
+            /// `Tin`.
+            pub fn from_item<'a, T>(
+                item: std::collections::HashMap<String, AttributeValue>,
+            ) -> Result<T>
+            where
+                T: serde::de::Deserialize<'a>,
+            {
+                crate::de::from_item(item)
+            }
+
+            /// A version of [`crate::from_items`] where the `Tin` generic is tied to
+            /// [`aws-sdk-dynamodbstreams::model::AttributeValue`](AttributeValue).
+            ///
+            /// Useful in very generic code where the type checker can't determine the type of
+            /// `Tin`.
+            pub fn from_items<'a, T>(
+                items: Vec<std::collections::HashMap<String, AttributeValue>>,
+            ) -> Result<Vec<T>>
+            where
+                T: serde::de::Deserialize<'a>,
+            {
+                crate::de::from_items(items)
+            }
+        }
+    };
+}
+
+pub(crate) use aws_sdk_streams_macro;

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,7 +1,9 @@
 mod aws_sdk;
+mod aws_sdk_streams;
 mod rusoto;
 mod rusoto_streams;
 
 pub(crate) use aws_sdk::aws_sdk_macro;
+pub(crate) use aws_sdk_streams::aws_sdk_streams_macro;
 pub(crate) use rusoto::rusoto_macro;
 pub(crate) use rusoto_streams::rusoto_streams_macro;


### PR DESCRIPTION
Adds support for handling `aws_sdk_dynamodbstreams::model::AttributeValue`

Modeled after how support for `rusoto_dynamodbstreams` works.