### PR TITLE
Update aws_sdk to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_dynamo"
-version = "3.0.0"
+version = "3.0.1-alpha.1"
 authors = ["Bryan Burgers <bryan@burgers.io>"]
 edition = "2021"
 license = "MIT"
@@ -14,6 +14,7 @@ keywords = ["serde", "rusoto", "dynamodb", "dynamo", "serde_dynamodb"]
 [dependencies]
 __aws_sdk_dynamodb_0_7 = { package = "aws-sdk-dynamodb", version = "0.7", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_8 = { package = "aws-sdk-dynamodb", version = "0.8", default-features = false, optional = true }
+__aws_sdk_dynamodb_0_9 = { package = "aws-sdk-dynamodb", version = "0.9", default-features = false, optional = true }
 __rusoto_dynamodb_0_46 = { package = "rusoto_dynamodb", version = "0.46", default-features = false, optional = true }
 __rusoto_dynamodb_0_47 = { package = "rusoto_dynamodb", version = "0.47", default-features = false, optional = true }
 __rusoto_dynamodbstreams_0_46 = { package = "rusoto_dynamodbstreams", version = "0.46", default-features = false, optional = true }
@@ -26,12 +27,13 @@ __rusoto_core_0_47_crate = { package = "rusoto_core", version = "0.47", default-
 [features]
 "aws-sdk-dynamodb+0_7" = ["__aws_sdk_dynamodb_0_7"]
 "aws-sdk-dynamodb+0_8" = ["__aws_sdk_dynamodb_0_8"]
+"aws-sdk-dynamodb+0_9" = ["__aws_sdk_dynamodb_0_9"]
 "rusoto_dynamodb+0_46" = ["__rusoto_dynamodb_0_46"]
 "rusoto_dynamodb+0_47" = ["__rusoto_dynamodb_0_47"]
 "rusoto_dynamodbstreams+0_46" = ["__rusoto_dynamodbstreams_0_46"]
 "rusoto_dynamodbstreams+0_47" = ["__rusoto_dynamodbstreams_0_47"]
 
-__doc = ["__rusoto_core_0_46_crate", "__rusoto_core_0_47_crate", "aws-sdk-dynamodb+0_7", "aws-sdk-dynamodb+0_8"]
+__doc = ["__rusoto_core_0_46_crate", "__rusoto_core_0_47_crate", "aws-sdk-dynamodb+0_7", "aws-sdk-dynamodb+0_8", "aws-sdk-dynamodb+0_9"]
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,10 +102,10 @@
 //!
 //! ```toml
 //! [dependencies]
-//! serde_dynamo = { version = "3", features = ["aws-sdk-dynamodb+0_8"] }
+//! serde_dynamo = { version = "3", features = ["aws-sdk-dynamodb+0_9"] }
 //! ```
 //!
-//! See [`__aws_sdk_dynamodb_0_8`] for examples and more information.
+//! See [`__aws_sdk_dynamodb_0_9`] for examples and more information.
 //!
 //!
 //! ## rusoto support
@@ -229,6 +229,12 @@ aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_8",
     crate_name = __aws_sdk_dynamodb_0_8,
     aws_version = "0.8",
+);
+
+aws_sdk_macro!(
+    feature = "aws-sdk-dynamodb+0_9",
+    crate_name = __aws_sdk_dynamodb_0_9,
+    aws_version = "0.9",
 );
 
 rusoto_macro!(


### PR DESCRIPTION
Hello, thanks for making this library. `aws_sdk` has been updated again, this adds a feature for 0.9. I've bumped the version to `3.0.1-alpha.1`, let me know if this is incorrect.

Cheers 🙏 