### PR TITLE
Fix issue #27

### DIFF
--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -562,3 +562,38 @@ fn deserialize_chrono_datetime() {
 
     assert_identical_json!(DateTime<Utc>, attribute_value.clone())
 }
+
+#[test]
+fn issue_27() {
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    struct Subject {
+        id: String,
+        #[serde(flatten)]
+        data: Data,
+    }
+
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    enum Data {
+        String(String),
+        Boolean(bool),
+    }
+
+    let attribute_value = AttributeValue::M(HashMap::from([
+        (String::from("id"), AttributeValue::S(String::from("test"))),
+        (
+            String::from("String"),
+            AttributeValue::S(String::from("the data")),
+        ),
+    ]));
+
+    let s: Subject = from_attribute_value(attribute_value.clone()).unwrap();
+    assert_eq!(
+        s,
+        Subject {
+            id: String::from("test"),
+            data: Data::String(String::from("the data"))
+        }
+    );
+
+    assert_identical_json!(Subject, attribute_value.clone());
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,10 @@ pub enum ErrorImpl {
     FailedToParseFloat(String, std::num::ParseFloatError),
     /// Key must be a string
     KeyMustBeAString,
+    /// SerializeMap's serialize_key called twice!
+    SerializeMapKeyCalledTwice,
+    /// SerializeMap's serialize_value called before serialize_key!
+    SerializeMapValueBeforeKey,
 }
 
 #[allow(clippy::from_over_into)]
@@ -94,6 +98,12 @@ impl Display for ErrorImpl {
                 write!(f, "Failed to parse '{0}' as a float: {1}", s, err)
             }
             ErrorImpl::KeyMustBeAString => f.write_str("Key must be a string"),
+            ErrorImpl::SerializeMapKeyCalledTwice => {
+                f.write_str("SerializeMap::serialize_key called twice")
+            }
+            ErrorImpl::SerializeMapValueBeforeKey => f.write_str(
+                "SerializeMap::serialize_value called before SerializeMap::serialize_key",
+            ),
         }
     }
 }

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -482,3 +482,45 @@ fn internally_tagged_enum() {
     assert_identical_json!(Enum::One { one: 1 });
     assert_identical_json!(Enum::Two { one: 1, two: 2 });
 }
+
+#[test]
+fn issue_27() {
+    #[derive(Serialize)]
+    struct Subject {
+        id: String,
+        #[serde(flatten)]
+        data: Data,
+    }
+
+    #[derive(Serialize)]
+    enum Data {
+        String(String),
+        Boolean(bool),
+    }
+
+    let result = to_attribute_value::<_, AttributeValue>(Subject {
+        id: String::from("test"),
+        data: Data::String(String::from("the data")),
+    })
+    .unwrap();
+
+    assert_eq!(
+        result,
+        AttributeValue::M(HashMap::from([
+            (String::from("id"), AttributeValue::S(String::from("test"))),
+            (
+                String::from("String"),
+                AttributeValue::S(String::from("the data"))
+            ),
+        ]))
+    );
+
+    assert_identical_json!(Subject {
+        id: String::from("test"),
+        data: Data::String(String::from("the data")),
+    });
+    assert_identical_json!(Subject {
+        id: String::from("test"),
+        data: Data::Boolean(true),
+    });
+}


### PR DESCRIPTION
Fix a situation where `SerializeMap::serialize_key` and
`SerializeMap::serialize_value` are called when I had previously assumed
that they could not be called.