### PR TITLE
Do not depend on specific dynamodb version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_dynamo"
-version = "3.0.2"
+version = "3.0.3"
 authors = ["Bryan Burgers <bryan@burgers.io>"]
 edition = "2021"
 license = "MIT"
@@ -15,8 +15,10 @@ keywords = ["serde", "rusoto", "dynamodb", "dynamo", "serde_dynamodb"]
 __aws_sdk_dynamodb_0_7 = { package = "aws-sdk-dynamodb", version = "0.7", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_8 = { package = "aws-sdk-dynamodb", version = "0.8", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_9 = { package = "aws-sdk-dynamodb", version = "0.9", default-features = false, optional = true }
+__aws_sdk_dynamodb_0_latest = { package = "aws-sdk-dynamodb", version = "~0", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_8 = { package = "aws-sdk-dynamodbstreams", version = "0.8", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_9 = { package = "aws-sdk-dynamodbstreams", version = "0.9", default-features = false, optional = true }
+__aws_sdk_dynamodbstreams_0_latest = { package = "aws-sdk-dynamodbstreams", version = "~0", default-features = false, optional = true }
 __rusoto_dynamodb_0_46 = { package = "rusoto_dynamodb", version = "0.46", default-features = false, optional = true }
 __rusoto_dynamodb_0_47 = { package = "rusoto_dynamodb", version = "0.47", default-features = false, optional = true }
 __rusoto_dynamodbstreams_0_46 = { package = "rusoto_dynamodbstreams", version = "0.46", default-features = false, optional = true }
@@ -30,14 +32,16 @@ __rusoto_core_0_47_crate = { package = "rusoto_core", version = "0.47", default-
 "aws-sdk-dynamodb+0_7" = ["__aws_sdk_dynamodb_0_7"]
 "aws-sdk-dynamodb+0_8" = ["__aws_sdk_dynamodb_0_8"]
 "aws-sdk-dynamodb+0_9" = ["__aws_sdk_dynamodb_0_9"]
+"aws-sdk-dynamodb+0_latest" = ["__aws_sdk_dynamodb_0_latest"]
 "aws-sdk-dynamodbstreams+0_8" = ["__aws_sdk_dynamodbstreams_0_8"]
 "aws-sdk-dynamodbstreams+0_9" = ["__aws_sdk_dynamodbstreams_0_9"]
+"aws-sdk-dynamodbstreams+0_latest" = ["__aws_sdk_dynamodbstreams_0_latest"]
 "rusoto_dynamodb+0_46" = ["__rusoto_dynamodb_0_46"]
 "rusoto_dynamodb+0_47" = ["__rusoto_dynamodb_0_47"]
 "rusoto_dynamodbstreams+0_46" = ["__rusoto_dynamodbstreams_0_46"]
 "rusoto_dynamodbstreams+0_47" = ["__rusoto_dynamodbstreams_0_47"]
 
-__doc = ["__rusoto_core_0_46_crate", "__rusoto_core_0_47_crate", "aws-sdk-dynamodb+0_7", "aws-sdk-dynamodb+0_8", "aws-sdk-dynamodb+0_9", "aws-sdk-dynamodbstreams+0_8", "aws-sdk-dynamodbstreams+0_9"]
+__doc = ["__rusoto_core_0_46_crate", "__rusoto_core_0_47_crate", "aws-sdk-dynamodb+0_7", "aws-sdk-dynamodb+0_8", "aws-sdk-dynamodb+0_9","aws-sdk-dynamodb+0_latest", "aws-sdk-dynamodbstreams+0_8", "aws-sdk-dynamodbstreams+0_9", "aws-sdk-dynamodbstreams+0_latest"]
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,12 @@ aws_sdk_macro!(
     aws_version = "0.9",
 );
 
+aws_sdk_macro!(
+    feature = "aws-sdk-dynamodb+0_latest",
+    crate_name = __aws_sdk_dynamodb_0_latest,
+    aws_version = "0",
+);
+
 aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_8",
     crate_name = __aws_sdk_dynamodbstreams_0_8,
@@ -259,7 +265,13 @@ aws_sdk_streams_macro!(
 aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_9",
     crate_name = __aws_sdk_dynamodbstreams_0_9,
-    aws_version = "0.8",
+    aws_version = "0.9",
+);
+
+aws_sdk_streams_macro!(
+    feature = "aws-sdk-dynamodbstreams+0_latest",
+    crate_name = __aws_sdk_dynamodbstreams_0_latest,
+    aws_version = "0",
 );
 
 rusoto_macro!(


### PR DESCRIPTION
Try to address issue (probably not 100% correct) where new release is needed every time there is new version of `aws sdk`. 

Removing hardcode version might make other problems, but most of them can be solved with:

```bash
cargo update -p aws-sdk-dynamodb:0.9.0 --precise 0.10.1
```

or

```bash
cargo update -p aws-sdk-dynamodb:0.10.1 --precise 0.9.0
```

With this approach you could probably axe other `features` with specific version.

Would this be something of interest?
