### PR TITLE
chore: Fix clippy warnings for 1.62.0

### DIFF
--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -34,7 +34,7 @@ macro_rules! deserialize_number {
     };
 }
 
-impl<'de, 'a> de::Deserializer<'de> for Deserializer {
+impl<'de> de::Deserializer<'de> for Deserializer {
     type Error = Error;
 
     // Look at the input data to decide what Serde data model type to

--- a/src/de/deserializer_bytes.rs
+++ b/src/de/deserializer_bytes.rs
@@ -12,7 +12,7 @@ impl<T> DeserializerBytes<T> {
     }
 }
 
-impl<'de, 'a, T> de::Deserializer<'de> for DeserializerBytes<T>
+impl<'de, T> de::Deserializer<'de> for DeserializerBytes<T>
 where
     T: AsRef<[u8]>,
 {

--- a/src/de/deserializer_enum.rs
+++ b/src/de/deserializer_enum.rs
@@ -14,7 +14,7 @@ impl DeserializerEnum {
     }
 }
 
-impl<'de, 'a> EnumAccess<'de> for DeserializerEnum {
+impl<'de> EnumAccess<'de> for DeserializerEnum {
     type Variant = DeserializerVariant;
     type Error = Error;
 
@@ -45,7 +45,7 @@ impl DeserializerVariant {
     }
 }
 
-impl<'de, 'a> VariantAccess<'de> for DeserializerVariant {
+impl<'de> VariantAccess<'de> for DeserializerVariant {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {

--- a/src/de/deserializer_number.rs
+++ b/src/de/deserializer_number.rs
@@ -47,7 +47,7 @@ macro_rules! deserialize_float {
     }};
 }
 
-impl<'de, 'a> de::Deserializer<'de> for DeserializerNumber {
+impl<'de> de::Deserializer<'de> for DeserializerNumber {
     type Error = Error;
 
     // Look at the input data to decide what Serde data model type to

--- a/src/de/deserializer_seq.rs
+++ b/src/de/deserializer_seq.rs
@@ -15,7 +15,7 @@ impl DeserializerSeq {
     }
 }
 
-impl<'de, 'a> SeqAccess<'de> for DeserializerSeq {
+impl<'de> SeqAccess<'de> for DeserializerSeq {
     type Error = Error;
 
     fn next_element_seed<S>(&mut self, seed: S) -> Result<Option<S::Value>, Self::Error>
@@ -43,7 +43,7 @@ impl DeserializerSeqStrings {
     }
 }
 
-impl<'de, 'a> SeqAccess<'de> for DeserializerSeqStrings {
+impl<'de> SeqAccess<'de> for DeserializerSeqStrings {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
@@ -71,7 +71,7 @@ impl DeserializerSeqNumbers {
     }
 }
 
-impl<'de, 'a> SeqAccess<'de> for DeserializerSeqNumbers {
+impl<'de> SeqAccess<'de> for DeserializerSeqNumbers {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
@@ -99,7 +99,7 @@ impl<T> DeserializerSeqBytes<T> {
     }
 }
 
-impl<'de, 'a, B> SeqAccess<'de> for DeserializerSeqBytes<B>
+impl<'de, B> SeqAccess<'de> for DeserializerSeqBytes<B>
 where
     B: AsRef<[u8]>,
 {

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -85,6 +85,7 @@ fn deserialize_char() {
 }
 
 #[test]
+#[allow(clippy::let_unit_value)]
 fn deserialize_unit() {
     let attribute_value = AttributeValue::Null(true);
     let result: () = from_attribute_value(attribute_value.clone()).unwrap();

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Serializer;
 
-impl<'a> ser::Serializer for Serializer {
+impl ser::Serializer for Serializer {
     type Ok = AttributeValue;
     type Error = Error;
 

--- a/src/ser/serializer_map.rs
+++ b/src/ser/serializer_map.rs
@@ -21,7 +21,7 @@ impl SerializerMap {
     }
 }
 
-impl<'a> ser::SerializeMap for SerializerMap {
+impl ser::SerializeMap for SerializerMap {
     type Ok = AttributeValue;
     type Error = Error;
 
@@ -74,7 +74,7 @@ impl<'a> ser::SerializeMap for SerializerMap {
 
 struct MapKeySerializer;
 
-impl<'a> ser::Serializer for MapKeySerializer {
+impl ser::Serializer for MapKeySerializer {
     type Ok = String;
     type Error = Error;
 
@@ -226,7 +226,7 @@ impl<'a> ser::Serializer for MapKeySerializer {
     }
 }
 
-impl<'a> ser::SerializeSeq for MapKeySerializer {
+impl ser::SerializeSeq for MapKeySerializer {
     type Ok = String;
     type Error = Error;
 
@@ -241,7 +241,7 @@ impl<'a> ser::SerializeSeq for MapKeySerializer {
         unreachable!()
     }
 }
-impl<'a> ser::SerializeTuple for MapKeySerializer {
+impl ser::SerializeTuple for MapKeySerializer {
     type Ok = String;
     type Error = Error;
 
@@ -256,7 +256,7 @@ impl<'a> ser::SerializeTuple for MapKeySerializer {
         unreachable!()
     }
 }
-impl<'a> ser::SerializeTupleStruct for MapKeySerializer {
+impl ser::SerializeTupleStruct for MapKeySerializer {
     type Ok = String;
     type Error = Error;
 
@@ -271,7 +271,7 @@ impl<'a> ser::SerializeTupleStruct for MapKeySerializer {
         unreachable!()
     }
 }
-impl<'a> ser::SerializeTupleVariant for MapKeySerializer {
+impl ser::SerializeTupleVariant for MapKeySerializer {
     type Ok = String;
     type Error = Error;
 
@@ -287,7 +287,7 @@ impl<'a> ser::SerializeTupleVariant for MapKeySerializer {
     }
 }
 
-impl<'a> ser::SerializeStructVariant for MapKeySerializer {
+impl ser::SerializeStructVariant for MapKeySerializer {
     type Ok = String;
     type Error = Error;
 
@@ -307,7 +307,7 @@ impl<'a> ser::SerializeStructVariant for MapKeySerializer {
     }
 }
 
-impl<'a> ser::SerializeMap for MapKeySerializer {
+impl ser::SerializeMap for MapKeySerializer {
     type Ok = String;
     type Error = Error;
 
@@ -342,7 +342,7 @@ impl<'a> ser::SerializeMap for MapKeySerializer {
     }
 }
 
-impl<'a> ser::SerializeStruct for MapKeySerializer {
+impl ser::SerializeStruct for MapKeySerializer {
     type Ok = String;
     type Error = Error;
 

--- a/src/ser/serializer_seq.rs
+++ b/src/ser/serializer_seq.rs
@@ -17,7 +17,7 @@ impl SerializerSeq {
     }
 }
 
-impl<'a> ser::SerializeSeq for SerializerSeq {
+impl ser::SerializeSeq for SerializerSeq {
     type Ok = AttributeValue;
     type Error = Error;
 
@@ -38,7 +38,7 @@ impl<'a> ser::SerializeSeq for SerializerSeq {
     }
 }
 
-impl<'a> ser::SerializeTupleStruct for SerializerSeq {
+impl ser::SerializeTupleStruct for SerializerSeq {
     type Ok = AttributeValue;
     type Error = Error;
 
@@ -58,7 +58,7 @@ impl<'a> ser::SerializeTupleStruct for SerializerSeq {
     }
 }
 
-impl<'a> ser::SerializeTuple for SerializerSeq {
+impl ser::SerializeTuple for SerializerSeq {
     type Ok = AttributeValue;
     type Error = Error;
 

--- a/src/ser/serializer_struct.rs
+++ b/src/ser/serializer_struct.rs
@@ -14,7 +14,7 @@ impl SerializerStruct {
     }
 }
 
-impl<'a> ser::SerializeStruct for SerializerStruct {
+impl ser::SerializeStruct for SerializerStruct {
     type Ok = AttributeValue;
     type Error = Error;
 

--- a/src/ser/serializer_struct_variant.rs
+++ b/src/ser/serializer_struct_variant.rs
@@ -16,7 +16,7 @@ impl SerializerStructVariant {
     }
 }
 
-impl<'a> ser::SerializeStructVariant for SerializerStructVariant {
+impl ser::SerializeStructVariant for SerializerStructVariant {
     type Ok = AttributeValue;
     type Error = Error;
 

--- a/src/ser/serializer_tuple_variant.rs
+++ b/src/ser/serializer_tuple_variant.rs
@@ -16,7 +16,7 @@ impl SerializerTupleVariant {
     }
 }
 
-impl<'a> ser::SerializeTupleVariant for SerializerTupleVariant {
+impl ser::SerializeTupleVariant for SerializerTupleVariant {
     type Ok = AttributeValue;
     type Error = Error;
 


### PR DESCRIPTION
Fix new clippy warnings that were released with Rust 1.62.0