### PR TITLE
Implement `From<&HashMap>` for `Item`

### DIFF
--- a/src/attribute_value.rs
+++ b/src/attribute_value.rs
@@ -107,6 +107,20 @@ where
     }
 }
 
+impl<T> From<&HashMap<String, T>> for Item
+where
+    AttributeValue: From<T>,
+    T: Clone,
+{
+    fn from(m: &HashMap<String, T>) -> Self {
+        Item(
+            m.into_iter()
+                .map(|(key, value)| (key.clone(), AttributeValue::from(value.clone())))
+                .collect(),
+        )
+    }
+}
+
 /// Multiple items that come from DynamoDb.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Items(Vec<Item>);
@@ -126,5 +140,20 @@ where
 {
     fn from(items: Vec<HashMap<String, T>>) -> Self {
         Items(items.into_iter().map(Into::into).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::from_item;
+    use serde_json::Value;
+
+    #[test]
+    fn from_item_aws_sdk_works() {
+        let mut item = HashMap::new();
+        item.insert("key".to_string(), AttributeValue::S("val".to_string()));
+
+        let _deserialized: Value = from_item(&item).unwrap();
     }
 }


### PR DESCRIPTION
Because [`item()`](https://docs.rs/aws-sdk-dynamodb/latest/aws_sdk_dynamodb/output/struct.GetItemOutput.html#method.item) and [`items()`](https://docs.rs/aws-sdk-dynamodb/latest/aws_sdk_dynamodb/output/struct.ScanOutput.html#method.items) both return references, calling `from_item()` / `from_items()` fails because the only [`From` impl for `Item`](https://docs.rs/serde_dynamo/latest/serde_dynamo/struct.Item.html#impl-From%3CHashMap%3CString%2C%20T%2C%20RandomState%3E%3E-for-Item) is an owned HashMap.

The examples in this crate are using [the undocumented](https://docs.rs/aws-sdk-dynamodb/latest/src/aws_sdk_dynamodb/output.rs.html#2339) (but still public) `item` field of the struct instead of the documented `items()` method, which is why it worked.