### PR TITLE
aws: Update docs for `.items` → `.items()`

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -48,7 +48,7 @@ where
 /// let result = client.scan().table_name("user").send().await?;
 ///
 /// // And deserialize them as strongly-typed data structures
-/// for item in result.items.unwrap() {
+/// for item in result.items().map(|slice| slice.to_vec()).unwrap() {
 ///     let user: User = from_item(item)?;
 ///     println!("{} is {}", user.name, user.age);
 /// }
@@ -84,7 +84,7 @@ where
 /// let result = client.scan().table_name("user").send().await?;
 ///
 /// // And deserialize them as strongly-typed data structures
-/// if let Some(items) = result.items {
+/// if let Some(items) = result.items().map(|slice| slice.to_vec()) {
 ///     let users: Vec<User> = from_items(items)?;
 ///     println!("Got {} users", users.len());
 /// }

--- a/src/macros/aws_sdk.rs
+++ b/src/macros/aws_sdk.rs
@@ -37,7 +37,7 @@ macro_rules! aws_sdk_macro {
             //! let result = client.scan().table_name("user").send().await?;
             //!
             //! // And deserialize them as strongly-typed data structures
-            //! if let Some(items) = result.items {
+            //! if let Some(items) = result.items().map(|slice| slice.to_vec()) {
             //!     let users: Vec<User> = from_items(items)?;
             //!     println!("Got {} users", users.len());
             //! }
@@ -64,7 +64,7 @@ macro_rules! aws_sdk_macro {
             //! let result = client.scan().table_name("user").send().await?;
             //!
             //! // And deserialize them as strongly-typed data structures
-            //! for item in result.items.unwrap() {
+            //! for item in result.items().map(|slice| slice.to_vec()).unwrap() {
             //!     let user: User = from_item(item)?;
             //!     println!("{} is {}", user.name, user.age);
             //! }


### PR DESCRIPTION
AWS SDK for DynamoDB used to expose the `.items` field from [ScanOutput],
etc.

As of version 0.16.0, the documentation for `.items` is hidden,
suggesting that the best way to interact with this structure is to use
`.items()` to get a slice of the items, and unnecessarily clone that
slice if you want to use it.

To prevent confusion, update the docs to use `.items()` instead of
`.items`.

Fixes #54, #55

[ScanOutput]: https://docs.rs/aws-sdk-dynamodb/0.22.0/aws_sdk_dynamodb/output/struct.ScanOutput.html
