### PR TITLE
feat: support newest aws-sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ __aws_sdk_dynamodb_0_21 = { package = "aws-sdk-dynamodb", version = "0.21", defa
 __aws_sdk_dynamodb_0_22 = { package = "aws-sdk-dynamodb", version = "0.22", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_23 = { package = "aws-sdk-dynamodb", version = "0.23", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_24 = { package = "aws-sdk-dynamodb", version = "0.24", default-features = false, optional = true }
+__aws_sdk_dynamodb_0_25 = { package = "aws-sdk-dynamodb", version = "0.25", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_8 = { package = "aws-sdk-dynamodbstreams", version = "0.8", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_9 = { package = "aws-sdk-dynamodbstreams", version = "0.9", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_10 = { package = "aws-sdk-dynamodbstreams", version = "0.10", default-features = false, optional = true }
@@ -47,6 +48,7 @@ __aws_sdk_dynamodbstreams_0_21 = { package = "aws-sdk-dynamodbstreams", version 
 __aws_sdk_dynamodbstreams_0_22 = { package = "aws-sdk-dynamodbstreams", version = "0.22", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_23 = { package = "aws-sdk-dynamodbstreams", version = "0.23", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_24 = { package = "aws-sdk-dynamodbstreams", version = "0.24", default-features = false, optional = true }
+__aws_sdk_dynamodbstreams_0_25 = { package = "aws-sdk-dynamodbstreams", version = "0.25", default-features = false, optional = true }
 __rusoto_dynamodb_0_46 = { package = "rusoto_dynamodb", version = "0.46", default-features = false, optional = true }
 __rusoto_dynamodb_0_47 = { package = "rusoto_dynamodb", version = "0.47", default-features = false, optional = true }
 __rusoto_dynamodb_0_48 = { package = "rusoto_dynamodb", version = "0.48", default-features = false, optional = true }
@@ -80,6 +82,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodb+0_22" = ["__aws_sdk_dynamodb_0_22"]
 "aws-sdk-dynamodb+0_23" = ["__aws_sdk_dynamodb_0_23"]
 "aws-sdk-dynamodb+0_24" = ["__aws_sdk_dynamodb_0_24"]
+"aws-sdk-dynamodb+0_25" = ["__aws_sdk_dynamodb_0_25"]
 "aws-sdk-dynamodbstreams+0_8" = ["__aws_sdk_dynamodbstreams_0_8"]
 "aws-sdk-dynamodbstreams+0_9" = ["__aws_sdk_dynamodbstreams_0_9"]
 "aws-sdk-dynamodbstreams+0_10" = ["__aws_sdk_dynamodbstreams_0_10"]
@@ -96,6 +99,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodbstreams+0_22" = ["__aws_sdk_dynamodbstreams_0_22"]
 "aws-sdk-dynamodbstreams+0_23" = ["__aws_sdk_dynamodbstreams_0_23"]
 "aws-sdk-dynamodbstreams+0_24" = ["__aws_sdk_dynamodbstreams_0_24"]
+"aws-sdk-dynamodbstreams+0_25" = ["__aws_sdk_dynamodbstreams_0_25"]
 "rusoto_dynamodb+0_46" = ["__rusoto_dynamodb_0_46"]
 "rusoto_dynamodb+0_47" = ["__rusoto_dynamodb_0_47"]
 "rusoto_dynamodb+0_48" = ["__rusoto_dynamodb_0_48"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,11 +102,11 @@
 //!
 //! ```toml
 //! [dependencies]
-//! serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_24"] }
+//! serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_25"] }
 //! ```
 //!
-//! See [`aws_sdk_dynamodb_0_24`] for examples and more information. See
-//! [`aws_sdk_dynamodbstreams_0_24`] for DynamoDb streams support.
+//! See [`aws_sdk_dynamodb_0_25`] for examples and more information. See
+//! [`aws_sdk_dynamodbstreams_0_25`] for DynamoDb streams support.
 //!
 //! ## aws_lambda_events support
 //!
@@ -392,6 +392,15 @@ aws_sdk_macro!(
     aws_version = "0.24",
 );
 
+aws_sdk_macro!(
+    feature = "aws-sdk-dynamodb+0_25",
+    crate_name = __aws_sdk_dynamodb_0_25,
+    mod_name = aws_sdk_dynamodb_0_25,
+    aws_version = "0.25",
+    primitives = primitives,
+    types = types,
+);
+
 aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_8",
     crate_name = __aws_sdk_dynamodbstreams_0_8,
@@ -502,6 +511,15 @@ aws_sdk_streams_macro!(
     crate_name = __aws_sdk_dynamodbstreams_0_24,
     mod_name = aws_sdk_dynamodbstreams_0_24,
     aws_version = "0.24",
+);
+
+aws_sdk_streams_macro!(
+    feature = "aws-sdk-dynamodbstreams+0_25",
+    crate_name = __aws_sdk_dynamodbstreams_0_25,
+    mod_name = aws_sdk_dynamodbstreams_0_25,
+    aws_version = "0.25",
+    primitives = primitives,
+    types = types,
 );
 
 rusoto_macro!(

--- a/src/macros/aws_sdk.rs
+++ b/src/macros/aws_sdk.rs
@@ -1,5 +1,15 @@
 macro_rules! aws_sdk_macro {
     (feature = $feature:literal, crate_name = $crate_name:ident, mod_name = $mod_name:ident, aws_version = $version:literal,) => {
+        aws_sdk_macro! {
+            feature = $feature,
+            crate_name = $crate_name,
+            mod_name = $mod_name,
+            aws_version = $version,
+            primitives = types,
+            types = model,
+        }
+    };
+    (feature = $feature:literal, crate_name = $crate_name:ident, mod_name = $mod_name:ident, aws_version = $version:literal, primitives = $primitives:ident, types = $types:ident,) => {
         #[cfg(feature = $feature)]
         #[cfg_attr(docsrs, doc(cfg(feature = $feature)))]
         pub mod $mod_name {
@@ -169,8 +179,8 @@ macro_rules! aws_sdk_macro {
             //! [aws_sdk_dynamodb::model::AttributeValue]: https://docs.rs/rusoto_dynamodb/0.47.0/rusoto_dynamodb/struct.AttributeValue.html
 
             use crate::Result;
-            use ::$crate_name::model::AttributeValue;
-            use ::$crate_name::types::Blob;
+            use ::$crate_name::$types::AttributeValue;
+            use ::$crate_name::$primitives::Blob;
 
             impl From<crate::AttributeValue> for AttributeValue {
                 fn from(attribute_value: crate::AttributeValue) -> AttributeValue {
@@ -277,7 +287,7 @@ macro_rules! aws_sdk_macro {
         #[deprecated(since = "4.0.0", note = "The double-underscore is no longer necessary")]
         pub mod $crate_name {
             use crate::Result;
-            use ::$crate_name::model::AttributeValue;
+            use ::$crate_name::$types::AttributeValue;
 
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>

--- a/src/macros/aws_sdk_streams.rs
+++ b/src/macros/aws_sdk_streams.rs
@@ -1,5 +1,15 @@
 macro_rules! aws_sdk_streams_macro {
     (feature = $feature:literal, crate_name = $crate_name:ident, mod_name = $mod_name:ident, aws_version = $version:literal,) => {
+        aws_sdk_streams_macro! {
+            feature = $feature,
+            crate_name = $crate_name,
+            mod_name = $mod_name,
+            aws_version = $version,
+            primitives = types,
+            types = model,
+        }
+    };
+    (feature = $feature:literal, crate_name = $crate_name:ident, mod_name = $mod_name:ident, aws_version = $version:literal, primitives = $primitives:ident, types = $types:ident,) => {
         #[cfg(feature = $feature)]
         #[cfg_attr(docsrs, doc(cfg(feature = $feature)))]
         pub mod $mod_name {
@@ -18,8 +28,8 @@ macro_rules! aws_sdk_streams_macro {
             //! [aws_sdk_dynamodbstreams::model::AttributeValue]: https://docs.rs/rusoto_dynamodbstreams/0.47.0/rusoto_dynamodbstreams/struct.AttributeValue.html
 
             use crate::Result;
-            use ::$crate_name::model::AttributeValue;
-            use ::$crate_name::types::Blob;
+            use ::$crate_name::$types::AttributeValue;
+            use ::$crate_name::$primitives::Blob;
 
             impl From<crate::AttributeValue> for AttributeValue {
                 fn from(attribute_value: crate::AttributeValue) -> AttributeValue {
@@ -126,7 +136,7 @@ macro_rules! aws_sdk_streams_macro {
         #[deprecated(since = "4.0.0", note = "The double-underscore is no longer necessary")]
         pub mod $crate_name {
             use crate::Result;
-            use ::$crate_name::model::AttributeValue;
+            use ::$crate_name::$types::AttributeValue;
 
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>


### PR DESCRIPTION
The documentation is still in the queue to be built on docs.rs, but I noticed a new version was published. Of note, some changes to the macros are required, and we may need to make changes to the way the doc comments are generated. There is a significant breaking change in the AWS Smithy generation. Notably, `Blob` is now `aws-sdk-dynamodb::primitives::Blob`, and `AttributeValue` is now `aws-sdk-dynamodb::types::AttributeValue`.

This probably isn't fully ready to merge, but it should give you a lead on figuring out how to adjust this crate to deal with the moved types.