### PR TITLE
Add aws-sdk-dynamodb 0.25 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ __aws_sdk_dynamodb_0_21 = { package = "aws-sdk-dynamodb", version = "0.21", defa
 __aws_sdk_dynamodb_0_22 = { package = "aws-sdk-dynamodb", version = "0.22", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_23 = { package = "aws-sdk-dynamodb", version = "0.23", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_24 = { package = "aws-sdk-dynamodb", version = "0.24", default-features = false, optional = true }
+__aws_sdk_dynamodb_0_25 = { package = "aws-sdk-dynamodb", version = "0.25", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_8 = { package = "aws-sdk-dynamodbstreams", version = "0.8", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_9 = { package = "aws-sdk-dynamodbstreams", version = "0.9", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_10 = { package = "aws-sdk-dynamodbstreams", version = "0.10", default-features = false, optional = true }
@@ -47,6 +48,7 @@ __aws_sdk_dynamodbstreams_0_21 = { package = "aws-sdk-dynamodbstreams", version 
 __aws_sdk_dynamodbstreams_0_22 = { package = "aws-sdk-dynamodbstreams", version = "0.22", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_23 = { package = "aws-sdk-dynamodbstreams", version = "0.23", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_24 = { package = "aws-sdk-dynamodbstreams", version = "0.24", default-features = false, optional = true }
+__aws_sdk_dynamodbstreams_0_25 = { package = "aws-sdk-dynamodbstreams", version = "0.25", default-features = false, optional = true }
 __rusoto_dynamodb_0_46 = { package = "rusoto_dynamodb", version = "0.46", default-features = false, optional = true }
 __rusoto_dynamodb_0_47 = { package = "rusoto_dynamodb", version = "0.47", default-features = false, optional = true }
 __rusoto_dynamodb_0_48 = { package = "rusoto_dynamodb", version = "0.48", default-features = false, optional = true }
@@ -80,6 +82,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodb+0_22" = ["__aws_sdk_dynamodb_0_22"]
 "aws-sdk-dynamodb+0_23" = ["__aws_sdk_dynamodb_0_23"]
 "aws-sdk-dynamodb+0_24" = ["__aws_sdk_dynamodb_0_24"]
+"aws-sdk-dynamodb+0_25" = ["__aws_sdk_dynamodb_0_25"]
 "aws-sdk-dynamodbstreams+0_8" = ["__aws_sdk_dynamodbstreams_0_8"]
 "aws-sdk-dynamodbstreams+0_9" = ["__aws_sdk_dynamodbstreams_0_9"]
 "aws-sdk-dynamodbstreams+0_10" = ["__aws_sdk_dynamodbstreams_0_10"]
@@ -96,6 +99,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodbstreams+0_22" = ["__aws_sdk_dynamodbstreams_0_22"]
 "aws-sdk-dynamodbstreams+0_23" = ["__aws_sdk_dynamodbstreams_0_23"]
 "aws-sdk-dynamodbstreams+0_24" = ["__aws_sdk_dynamodbstreams_0_24"]
+"aws-sdk-dynamodbstreams+0_25" = ["__aws_sdk_dynamodbstreams_0_25"]
 "rusoto_dynamodb+0_46" = ["__rusoto_dynamodb_0_46"]
 "rusoto_dynamodb+0_47" = ["__rusoto_dynamodb_0_47"]
 "rusoto_dynamodb+0_48" = ["__rusoto_dynamodb_0_48"]

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -32,7 +32,7 @@ where
 /// Interpret an [`Item`] as an instance of type `T`.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_24::client::Client;
+/// # use __aws_sdk_dynamodb_0_25::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::from_item;
 /// #
@@ -68,7 +68,7 @@ where
 /// Interpret a [`Items`] as a `Vec<T>`.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_24::client::Client;
+/// # use __aws_sdk_dynamodb_0_25::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::from_items;
 /// #

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,11 +102,11 @@
 //!
 //! ```toml
 //! [dependencies]
-//! serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_24"] }
+//! serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_25"] }
 //! ```
 //!
-//! See [`aws_sdk_dynamodb_0_24`] for examples and more information. See
-//! [`aws_sdk_dynamodbstreams_0_24`] for DynamoDb streams support.
+//! See [`aws_sdk_dynamodb_0_25`] for examples and more information. See
+//! [`aws_sdk_dynamodbstreams_0_25`] for DynamoDb streams support.
 //!
 //! ## aws_lambda_events support
 //!
@@ -278,125 +278,188 @@ aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_7",
     crate_name = __aws_sdk_dynamodb_0_7,
     mod_name = aws_sdk_dynamodb_0_7,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_7::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_7::types::Blob,
     aws_version = "0.7",
+    config_version = "0.7",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_8",
     crate_name = __aws_sdk_dynamodb_0_8,
     mod_name = aws_sdk_dynamodb_0_8,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_8::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_8::types::Blob,
     aws_version = "0.8",
+    config_version = "0.8",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_9",
     crate_name = __aws_sdk_dynamodb_0_9,
     mod_name = aws_sdk_dynamodb_0_9,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_9::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_9::types::Blob,
     aws_version = "0.9",
+    config_version = "0.9",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_10",
     crate_name = __aws_sdk_dynamodb_0_10,
     mod_name = aws_sdk_dynamodb_0_10,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_10::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_10::types::Blob,
     aws_version = "0.10",
+    config_version = "0.40",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_11",
     crate_name = __aws_sdk_dynamodb_0_11,
     mod_name = aws_sdk_dynamodb_0_11,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_11::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_11::types::Blob,
     aws_version = "0.11",
+    config_version = "0.41",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_12",
     crate_name = __aws_sdk_dynamodb_0_12,
     mod_name = aws_sdk_dynamodb_0_12,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_12::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_12::types::Blob,
     aws_version = "0.12",
+    config_version = "0.42",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_13",
     crate_name = __aws_sdk_dynamodb_0_13,
     mod_name = aws_sdk_dynamodb_0_13,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_13::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_13::types::Blob,
     aws_version = "0.13",
+    config_version = "0.43",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_14",
     crate_name = __aws_sdk_dynamodb_0_14,
     mod_name = aws_sdk_dynamodb_0_14,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_14::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_14::types::Blob,
     aws_version = "0.14",
+    config_version = "0.44",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_15",
     crate_name = __aws_sdk_dynamodb_0_15,
     mod_name = aws_sdk_dynamodb_0_15,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_15::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_15::types::Blob,
     aws_version = "0.15",
+    config_version = "0.45",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_16",
     crate_name = __aws_sdk_dynamodb_0_16,
     mod_name = aws_sdk_dynamodb_0_16,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_16::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_16::types::Blob,
     aws_version = "0.16",
+    config_version = "0.46",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_17",
     crate_name = __aws_sdk_dynamodb_0_17,
     mod_name = aws_sdk_dynamodb_0_17,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_17::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_17::types::Blob,
     aws_version = "0.17",
+    config_version = "0.47",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_18",
     crate_name = __aws_sdk_dynamodb_0_18,
     mod_name = aws_sdk_dynamodb_0_18,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_18::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_18::types::Blob,
     aws_version = "0.18",
+    config_version = "0.48",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_19",
     crate_name = __aws_sdk_dynamodb_0_19,
     mod_name = aws_sdk_dynamodb_0_19,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_19::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_19::types::Blob,
     aws_version = "0.19",
+    config_version = "0.49",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_21",
     crate_name = __aws_sdk_dynamodb_0_21,
     mod_name = aws_sdk_dynamodb_0_21,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_21::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_21::types::Blob,
     aws_version = "0.21",
+    config_version = "0.51",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_22",
     crate_name = __aws_sdk_dynamodb_0_22,
     mod_name = aws_sdk_dynamodb_0_22,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_22::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_22::types::Blob,
     aws_version = "0.22",
+    config_version = "0.52",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_23",
     crate_name = __aws_sdk_dynamodb_0_23,
     mod_name = aws_sdk_dynamodb_0_23,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_23::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_23::types::Blob,
     aws_version = "0.23",
+    config_version = "0.53",
 );
 
 aws_sdk_macro!(
     feature = "aws-sdk-dynamodb+0_24",
     crate_name = __aws_sdk_dynamodb_0_24,
     mod_name = aws_sdk_dynamodb_0_24,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_24::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_24::types::Blob,
     aws_version = "0.24",
+    config_version = "0.54",
+);
+
+aws_sdk_macro!(
+    feature = "aws-sdk-dynamodb+0_25",
+    crate_name = __aws_sdk_dynamodb_0_25,
+    mod_name = aws_sdk_dynamodb_0_25,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_25::types::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_25::primitives::Blob,
+    aws_version = "0.25",
+    config_version = "0.55",
 );
 
 aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_8",
     crate_name = __aws_sdk_dynamodbstreams_0_8,
     mod_name = aws_sdk_dynamodbstreams_0_8,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_8::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_8::types::Blob,
     aws_version = "0.8",
 );
 
@@ -404,6 +467,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_9",
     crate_name = __aws_sdk_dynamodbstreams_0_9,
     mod_name = aws_sdk_dynamodbstreams_0_9,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_9::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_9::types::Blob,
     aws_version = "0.9",
 );
 
@@ -411,6 +476,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_10",
     crate_name = __aws_sdk_dynamodbstreams_0_10,
     mod_name = aws_sdk_dynamodbstreams_0_10,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_10::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_10::types::Blob,
     aws_version = "0.10",
 );
 
@@ -418,6 +485,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_11",
     crate_name = __aws_sdk_dynamodbstreams_0_11,
     mod_name = aws_sdk_dynamodbstreams_0_11,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_11::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_11::types::Blob,
     aws_version = "0.11",
 );
 
@@ -425,6 +494,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_12",
     crate_name = __aws_sdk_dynamodbstreams_0_12,
     mod_name = aws_sdk_dynamodbstreams_0_12,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_12::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_12::types::Blob,
     aws_version = "0.12",
 );
 
@@ -432,6 +503,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_13",
     crate_name = __aws_sdk_dynamodbstreams_0_13,
     mod_name = aws_sdk_dynamodbstreams_0_13,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_13::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_13::types::Blob,
     aws_version = "0.13",
 );
 
@@ -439,6 +512,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_14",
     crate_name = __aws_sdk_dynamodbstreams_0_14,
     mod_name = aws_sdk_dynamodbstreams_0_14,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_14::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_14::types::Blob,
     aws_version = "0.14",
 );
 
@@ -446,6 +521,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_15",
     crate_name = __aws_sdk_dynamodbstreams_0_15,
     mod_name = aws_sdk_dynamodbstreams_0_15,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_15::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_15::types::Blob,
     aws_version = "0.15",
 );
 
@@ -453,6 +530,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_16",
     crate_name = __aws_sdk_dynamodbstreams_0_16,
     mod_name = aws_sdk_dynamodbstreams_0_16,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_16::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_16::types::Blob,
     aws_version = "0.16",
 );
 
@@ -460,6 +539,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_17",
     crate_name = __aws_sdk_dynamodbstreams_0_17,
     mod_name = aws_sdk_dynamodbstreams_0_17,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_17::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_17::types::Blob,
     aws_version = "0.17",
 );
 
@@ -467,6 +548,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_18",
     crate_name = __aws_sdk_dynamodbstreams_0_18,
     mod_name = aws_sdk_dynamodbstreams_0_18,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_18::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_18::types::Blob,
     aws_version = "0.18",
 );
 
@@ -474,6 +557,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_19",
     crate_name = __aws_sdk_dynamodbstreams_0_19,
     mod_name = aws_sdk_dynamodbstreams_0_19,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_19::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_19::types::Blob,
     aws_version = "0.19",
 );
 
@@ -481,6 +566,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_21",
     crate_name = __aws_sdk_dynamodbstreams_0_21,
     mod_name = aws_sdk_dynamodbstreams_0_21,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_21::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_21::types::Blob,
     aws_version = "0.21",
 );
 
@@ -488,6 +575,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_22",
     crate_name = __aws_sdk_dynamodbstreams_0_22,
     mod_name = aws_sdk_dynamodbstreams_0_22,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_22::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_22::types::Blob,
     aws_version = "0.22",
 );
 
@@ -495,6 +584,8 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_23",
     crate_name = __aws_sdk_dynamodbstreams_0_23,
     mod_name = aws_sdk_dynamodbstreams_0_23,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_23::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_23::types::Blob,
     aws_version = "0.23",
 );
 
@@ -502,7 +593,18 @@ aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_24",
     crate_name = __aws_sdk_dynamodbstreams_0_24,
     mod_name = aws_sdk_dynamodbstreams_0_24,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_24::model::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_24::types::Blob,
     aws_version = "0.24",
+);
+
+aws_sdk_streams_macro!(
+    feature = "aws-sdk-dynamodbstreams+0_25",
+    crate_name = __aws_sdk_dynamodbstreams_0_25,
+    mod_name = aws_sdk_dynamodbstreams_0_25,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_25::types::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_25::primitives::Blob,
+    aws_version = "0.25",
 );
 
 rusoto_macro!(

--- a/src/macros/aws_sdk.rs
+++ b/src/macros/aws_sdk.rs
@@ -1,5 +1,13 @@
 macro_rules! aws_sdk_macro {
-    (feature = $feature:literal, crate_name = $crate_name:ident, mod_name = $mod_name:ident, aws_version = $version:literal,) => {
+    (
+        feature = $feature:literal,
+        crate_name = $crate_name:ident,
+        mod_name = $mod_name:ident,
+        attribute_value_path = $attribute_value_path:path,
+        blob_path = $blob_path:path,
+        aws_version = $version:literal,
+        config_version = $config_version:literal,
+    ) => {
         #[cfg(feature = $feature)]
         #[cfg_attr(docsrs, doc(cfg(feature = $feature)))]
         pub mod $mod_name {
@@ -10,7 +18,7 @@ macro_rules! aws_sdk_macro {
             //!
             //! ```toml
             //! [dependencies]
-            #![doc = concat!("aws-config = ", stringify!($version))]
+            #![doc = concat!("aws-config = ", stringify!($config_version))]
             #![doc = concat!("aws-sdk-dynamodb = ", stringify!($version))]
             #![doc = concat!("serde_dynamo = { version = \"3\", features = [", stringify!($feature), "] }")]
             //! ```
@@ -169,8 +177,8 @@ macro_rules! aws_sdk_macro {
             //! [aws_sdk_dynamodb::model::AttributeValue]: https://docs.rs/rusoto_dynamodb/0.47.0/rusoto_dynamodb/struct.AttributeValue.html
 
             use crate::Result;
-            use ::$crate_name::model::AttributeValue;
-            use ::$crate_name::types::Blob;
+            use $attribute_value_path;
+            use $blob_path;
 
             impl From<crate::AttributeValue> for AttributeValue {
                 fn from(attribute_value: crate::AttributeValue) -> AttributeValue {
@@ -277,7 +285,7 @@ macro_rules! aws_sdk_macro {
         #[deprecated(since = "4.0.0", note = "The double-underscore is no longer necessary")]
         pub mod $crate_name {
             use crate::Result;
-            use ::$crate_name::model::AttributeValue;
+            use $attribute_value_path;
 
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>

--- a/src/macros/aws_sdk_streams.rs
+++ b/src/macros/aws_sdk_streams.rs
@@ -1,5 +1,12 @@
 macro_rules! aws_sdk_streams_macro {
-    (feature = $feature:literal, crate_name = $crate_name:ident, mod_name = $mod_name:ident, aws_version = $version:literal,) => {
+    (
+        feature = $feature:literal,
+        crate_name = $crate_name:ident,
+        mod_name = $mod_name:ident,
+        attribute_value_path = $attribute_value_path:path,
+        blob_path = $blob_path:path,
+        aws_version = $version:literal,
+    ) => {
         #[cfg(feature = $feature)]
         #[cfg_attr(docsrs, doc(cfg(feature = $feature)))]
         pub mod $mod_name {
@@ -18,8 +25,8 @@ macro_rules! aws_sdk_streams_macro {
             //! [aws_sdk_dynamodbstreams::model::AttributeValue]: https://docs.rs/rusoto_dynamodbstreams/0.47.0/rusoto_dynamodbstreams/struct.AttributeValue.html
 
             use crate::Result;
-            use ::$crate_name::model::AttributeValue;
-            use ::$crate_name::types::Blob;
+            use $attribute_value_path;
+            use $blob_path;
 
             impl From<crate::AttributeValue> for AttributeValue {
                 fn from(attribute_value: crate::AttributeValue) -> AttributeValue {
@@ -126,7 +133,7 @@ macro_rules! aws_sdk_streams_macro {
         #[deprecated(since = "4.0.0", note = "The double-underscore is no longer necessary")]
         pub mod $crate_name {
             use crate::Result;
-            use ::$crate_name::model::AttributeValue;
+            use $attribute_value_path;
 
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -27,7 +27,7 @@ use serializer_tuple_variant::SerializerTupleVariant;
 ///
 /// ```no_run
 /// use serde_dynamo::to_attribute_value;
-/// # use __aws_sdk_dynamodb_0_24::client::Client;
+/// # use __aws_sdk_dynamodb_0_25::client::Client;
 /// # use std::collections::HashMap;
 /// #
 /// # async fn get(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -50,7 +50,7 @@ use serializer_tuple_variant::SerializerTupleVariant;
 ///
 /// ```no_run
 /// use serde_dynamo::to_attribute_value;
-/// # use __aws_sdk_dynamodb_0_24::client::Client;
+/// # use __aws_sdk_dynamodb_0_25::client::Client;
 /// # use std::collections::HashMap;
 /// #
 /// # async fn query(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -94,7 +94,7 @@ where
 /// This is frequently used when serializing an entire data structure to be sent to DynamoDB.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_24::client::Client;
+/// # use __aws_sdk_dynamodb_0_25::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::to_item;
 /// #


### PR DESCRIPTION
Some of the paths changed in the 0.25 release, so make the macros
dynamic enough to handle them.

Also, we've been using the wrong aws_config version all along. Update
that as well.
