### PR TITLE
Add aws-sdk-dynamodb 0.26 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ __aws_sdk_dynamodb_0_22 = { package = "aws-sdk-dynamodb", version = "0.22", defa
 __aws_sdk_dynamodb_0_23 = { package = "aws-sdk-dynamodb", version = "0.23", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_24 = { package = "aws-sdk-dynamodb", version = "0.24", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_25 = { package = "aws-sdk-dynamodb", version = "0.25", default-features = false, optional = true }
+__aws_sdk_dynamodb_0_26 = { package = "aws-sdk-dynamodb", version = "0.26", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_8 = { package = "aws-sdk-dynamodbstreams", version = "0.8", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_9 = { package = "aws-sdk-dynamodbstreams", version = "0.9", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_10 = { package = "aws-sdk-dynamodbstreams", version = "0.10", default-features = false, optional = true }
@@ -49,6 +50,7 @@ __aws_sdk_dynamodbstreams_0_22 = { package = "aws-sdk-dynamodbstreams", version 
 __aws_sdk_dynamodbstreams_0_23 = { package = "aws-sdk-dynamodbstreams", version = "0.23", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_24 = { package = "aws-sdk-dynamodbstreams", version = "0.24", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_25 = { package = "aws-sdk-dynamodbstreams", version = "0.25", default-features = false, optional = true }
+__aws_sdk_dynamodbstreams_0_26 = { package = "aws-sdk-dynamodbstreams", version = "0.26", default-features = false, optional = true }
 __rusoto_dynamodb_0_46 = { package = "rusoto_dynamodb", version = "0.46", default-features = false, optional = true }
 __rusoto_dynamodb_0_47 = { package = "rusoto_dynamodb", version = "0.47", default-features = false, optional = true }
 __rusoto_dynamodb_0_48 = { package = "rusoto_dynamodb", version = "0.48", default-features = false, optional = true }
@@ -83,6 +85,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodb+0_23" = ["__aws_sdk_dynamodb_0_23"]
 "aws-sdk-dynamodb+0_24" = ["__aws_sdk_dynamodb_0_24"]
 "aws-sdk-dynamodb+0_25" = ["__aws_sdk_dynamodb_0_25"]
+"aws-sdk-dynamodb+0_26" = ["__aws_sdk_dynamodb_0_26"]
 "aws-sdk-dynamodbstreams+0_8" = ["__aws_sdk_dynamodbstreams_0_8"]
 "aws-sdk-dynamodbstreams+0_9" = ["__aws_sdk_dynamodbstreams_0_9"]
 "aws-sdk-dynamodbstreams+0_10" = ["__aws_sdk_dynamodbstreams_0_10"]
@@ -100,6 +103,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodbstreams+0_23" = ["__aws_sdk_dynamodbstreams_0_23"]
 "aws-sdk-dynamodbstreams+0_24" = ["__aws_sdk_dynamodbstreams_0_24"]
 "aws-sdk-dynamodbstreams+0_25" = ["__aws_sdk_dynamodbstreams_0_25"]
+"aws-sdk-dynamodbstreams+0_26" = ["__aws_sdk_dynamodbstreams_0_26"]
 "rusoto_dynamodb+0_46" = ["__rusoto_dynamodb_0_46"]
 "rusoto_dynamodb+0_47" = ["__rusoto_dynamodb_0_47"]
 "rusoto_dynamodb+0_48" = ["__rusoto_dynamodb_0_48"]

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -32,7 +32,7 @@ where
 /// Interpret an [`Item`] as an instance of type `T`.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_25::client::Client;
+/// # use __aws_sdk_dynamodb_0_26::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::from_item;
 /// #
@@ -68,7 +68,7 @@ where
 /// Interpret a [`Items`] as a `Vec<T>`.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_25::client::Client;
+/// # use __aws_sdk_dynamodb_0_26::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::from_items;
 /// #

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,11 +102,11 @@
 //!
 //! ```toml
 //! [dependencies]
-//! serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_25"] }
+//! serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_26"] }
 //! ```
 //!
-//! See [`aws_sdk_dynamodb_0_25`] for examples and more information. See
-//! [`aws_sdk_dynamodbstreams_0_25`] for DynamoDb streams support.
+//! See [`aws_sdk_dynamodb_0_26`] for examples and more information. See
+//! [`aws_sdk_dynamodbstreams_0_26`] for DynamoDb streams support.
 //!
 //! ## aws_lambda_events support
 //!
@@ -454,6 +454,16 @@ aws_sdk_macro!(
     config_version = "0.55",
 );
 
+aws_sdk_macro!(
+    feature = "aws-sdk-dynamodb+0_26",
+    crate_name = __aws_sdk_dynamodb_0_26,
+    mod_name = aws_sdk_dynamodb_0_26,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_26::types::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_26::primitives::Blob,
+    aws_version = "0.26",
+    config_version = "0.55",
+);
+
 aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_8",
     crate_name = __aws_sdk_dynamodbstreams_0_8,
@@ -605,6 +615,15 @@ aws_sdk_streams_macro!(
     attribute_value_path = ::__aws_sdk_dynamodbstreams_0_25::types::AttributeValue,
     blob_path = ::__aws_sdk_dynamodbstreams_0_25::primitives::Blob,
     aws_version = "0.25",
+);
+
+aws_sdk_streams_macro!(
+    feature = "aws-sdk-dynamodbstreams+0_26",
+    crate_name = __aws_sdk_dynamodbstreams_0_26,
+    mod_name = aws_sdk_dynamodbstreams_0_26,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_26::types::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_26::primitives::Blob,
+    aws_version = "0.26",
 );
 
 rusoto_macro!(

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -27,7 +27,7 @@ use serializer_tuple_variant::SerializerTupleVariant;
 ///
 /// ```no_run
 /// use serde_dynamo::to_attribute_value;
-/// # use __aws_sdk_dynamodb_0_25::client::Client;
+/// # use __aws_sdk_dynamodb_0_26::client::Client;
 /// # use std::collections::HashMap;
 /// #
 /// # async fn get(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -50,7 +50,7 @@ use serializer_tuple_variant::SerializerTupleVariant;
 ///
 /// ```no_run
 /// use serde_dynamo::to_attribute_value;
-/// # use __aws_sdk_dynamodb_0_25::client::Client;
+/// # use __aws_sdk_dynamodb_0_26::client::Client;
 /// # use std::collections::HashMap;
 /// #
 /// # async fn query(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -94,7 +94,7 @@ where
 /// This is frequently used when serializing an entire data structure to be sent to DynamoDB.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_25::client::Client;
+/// # use __aws_sdk_dynamodb_0_26::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::to_item;
 /// #


### PR DESCRIPTION
Feel free to amend if I missed something, thanks.

Builds fine with `cargo build --features="aws-sdk-dynamodb+0_26"`
Passed `cargo test --all-targets --features aws-sdk-dynamodb+0_26`