### PR TITLE
Fix URL for aws_sdk_dynamodb::model::AttributeValue

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -78,7 +78,7 @@ use serializer_tuple_variant::SerializerTupleVariant;
 /// [get_item]: https://docs.rs/aws-sdk-dynamodb/*/aws_sdk_dynamodb/client/struct.Client.html#method.get_item
 /// [put_item]: https://docs.rs/aws-sdk-dynamodb/*/aws_sdk_dynamodb/client/struct.Client.html#method.put_item
 /// [query]: https://docs.rs/aws-sdk-dynamodb/*/aws_sdk_dynamodb/client/struct.Client.html#method.query
-/// [aws_sdk_dynamodb::model::AttributeValue]: https://docs.rs/rusoto_dynamodb/0.47.0/rusoto_dynamodb/struct.AttributeValue.html
+/// [aws_sdk_dynamodb::model::AttributeValue]: https://docs.rs/aws-sdk-dynamodb/*/aws_sdk_dynamodb/types/enum.AttributeValue.html
 pub fn to_attribute_value<T, AV>(value: T) -> Result<AV>
 where
     T: Serialize,


### PR DESCRIPTION
Hi, thanks for this useful implementation.

I looked at the `to_attribute_value()` document and felt that the link was not appropriate, so I have fixed it.

https://docs.rs/serde_dynamo/4.2.5/serde_dynamo/fn.to_attribute_value.html

If the before URL had some intention, please close it.