### PR TITLE
Support for `aws-sdk-dynamodb` 0.32 and 0.33.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ __aws_sdk_dynamodb_0_28 = { package = "aws-sdk-dynamodb", version = "0.28", defa
 __aws_sdk_dynamodb_0_29 = { package = "aws-sdk-dynamodb", version = "0.29", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_30 = { package = "aws-sdk-dynamodb", version = "0.30", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_31 = { package = "aws-sdk-dynamodb", version = "0.31", default-features = false, optional = true }
+__aws_sdk_dynamodb_0_32 = { package = "aws-sdk-dynamodb", version = "0.32", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_8 = { package = "aws-sdk-dynamodbstreams", version = "0.8", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_9 = { package = "aws-sdk-dynamodbstreams", version = "0.9", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_10 = { package = "aws-sdk-dynamodbstreams", version = "0.10", default-features = false, optional = true }
@@ -61,6 +62,7 @@ __aws_sdk_dynamodbstreams_0_28 = { package = "aws-sdk-dynamodbstreams", version 
 __aws_sdk_dynamodbstreams_0_29 = { package = "aws-sdk-dynamodbstreams", version = "0.29", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_30 = { package = "aws-sdk-dynamodbstreams", version = "0.30", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_31 = { package = "aws-sdk-dynamodbstreams", version = "0.31", default-features = false, optional = true }
+__aws_sdk_dynamodbstreams_0_32 = { package = "aws-sdk-dynamodbstreams", version = "0.32", default-features = false, optional = true }
 __rusoto_dynamodb_0_46 = { package = "rusoto_dynamodb", version = "0.46", default-features = false, optional = true }
 __rusoto_dynamodb_0_47 = { package = "rusoto_dynamodb", version = "0.47", default-features = false, optional = true }
 __rusoto_dynamodb_0_48 = { package = "rusoto_dynamodb", version = "0.48", default-features = false, optional = true }
@@ -101,6 +103,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodb+0_29" = ["__aws_sdk_dynamodb_0_29"]
 "aws-sdk-dynamodb+0_30" = ["__aws_sdk_dynamodb_0_30"]
 "aws-sdk-dynamodb+0_31" = ["__aws_sdk_dynamodb_0_31"]
+"aws-sdk-dynamodb+0_32" = ["__aws_sdk_dynamodb_0_32"]
 "aws-sdk-dynamodbstreams+0_8" = ["__aws_sdk_dynamodbstreams_0_8"]
 "aws-sdk-dynamodbstreams+0_9" = ["__aws_sdk_dynamodbstreams_0_9"]
 "aws-sdk-dynamodbstreams+0_10" = ["__aws_sdk_dynamodbstreams_0_10"]
@@ -124,6 +127,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodbstreams+0_29" = ["__aws_sdk_dynamodbstreams_0_29"]
 "aws-sdk-dynamodbstreams+0_30" = ["__aws_sdk_dynamodbstreams_0_30"]
 "aws-sdk-dynamodbstreams+0_31" = ["__aws_sdk_dynamodbstreams_0_31"]
+"aws-sdk-dynamodbstreams+0_32" = ["__aws_sdk_dynamodbstreams_0_32"]
 "rusoto_dynamodb+0_46" = ["__rusoto_dynamodb_0_46"]
 "rusoto_dynamodb+0_47" = ["__rusoto_dynamodb_0_47"]
 "rusoto_dynamodb+0_48" = ["__rusoto_dynamodb_0_48"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ __aws_sdk_dynamodb_0_29 = { package = "aws-sdk-dynamodb", version = "0.29", defa
 __aws_sdk_dynamodb_0_30 = { package = "aws-sdk-dynamodb", version = "0.30", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_31 = { package = "aws-sdk-dynamodb", version = "0.31", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_32 = { package = "aws-sdk-dynamodb", version = "0.32", default-features = false, optional = true }
+__aws_sdk_dynamodb_0_33 = { package = "aws-sdk-dynamodb", version = "0.33", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_8 = { package = "aws-sdk-dynamodbstreams", version = "0.8", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_9 = { package = "aws-sdk-dynamodbstreams", version = "0.9", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_10 = { package = "aws-sdk-dynamodbstreams", version = "0.10", default-features = false, optional = true }
@@ -63,6 +64,7 @@ __aws_sdk_dynamodbstreams_0_29 = { package = "aws-sdk-dynamodbstreams", version 
 __aws_sdk_dynamodbstreams_0_30 = { package = "aws-sdk-dynamodbstreams", version = "0.30", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_31 = { package = "aws-sdk-dynamodbstreams", version = "0.31", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_32 = { package = "aws-sdk-dynamodbstreams", version = "0.32", default-features = false, optional = true }
+__aws_sdk_dynamodbstreams_0_33 = { package = "aws-sdk-dynamodbstreams", version = "0.33", default-features = false, optional = true }
 __rusoto_dynamodb_0_46 = { package = "rusoto_dynamodb", version = "0.46", default-features = false, optional = true }
 __rusoto_dynamodb_0_47 = { package = "rusoto_dynamodb", version = "0.47", default-features = false, optional = true }
 __rusoto_dynamodb_0_48 = { package = "rusoto_dynamodb", version = "0.48", default-features = false, optional = true }
@@ -104,6 +106,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodb+0_30" = ["__aws_sdk_dynamodb_0_30"]
 "aws-sdk-dynamodb+0_31" = ["__aws_sdk_dynamodb_0_31"]
 "aws-sdk-dynamodb+0_32" = ["__aws_sdk_dynamodb_0_32"]
+"aws-sdk-dynamodb+0_33" = ["__aws_sdk_dynamodb_0_33"]
 "aws-sdk-dynamodbstreams+0_8" = ["__aws_sdk_dynamodbstreams_0_8"]
 "aws-sdk-dynamodbstreams+0_9" = ["__aws_sdk_dynamodbstreams_0_9"]
 "aws-sdk-dynamodbstreams+0_10" = ["__aws_sdk_dynamodbstreams_0_10"]
@@ -128,6 +131,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodbstreams+0_30" = ["__aws_sdk_dynamodbstreams_0_30"]
 "aws-sdk-dynamodbstreams+0_31" = ["__aws_sdk_dynamodbstreams_0_31"]
 "aws-sdk-dynamodbstreams+0_32" = ["__aws_sdk_dynamodbstreams_0_32"]
+"aws-sdk-dynamodbstreams+0_33" = ["__aws_sdk_dynamodbstreams_0_33"]
 "rusoto_dynamodb+0_46" = ["__rusoto_dynamodb_0_46"]
 "rusoto_dynamodb+0_47" = ["__rusoto_dynamodb_0_47"]
 "rusoto_dynamodb+0_48" = ["__rusoto_dynamodb_0_48"]

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -32,7 +32,7 @@ where
 /// Interpret an [`Item`] as an instance of type `T`.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_31::client::Client;
+/// # use __aws_sdk_dynamodb_0_32::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::from_item;
 /// #
@@ -68,7 +68,7 @@ where
 /// Interpret a [`Items`] as a `Vec<T>`.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_31::client::Client;
+/// # use __aws_sdk_dynamodb_0_32::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::from_items;
 /// #

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -32,7 +32,7 @@ where
 /// Interpret an [`Item`] as an instance of type `T`.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_32::client::Client;
+/// # use __aws_sdk_dynamodb_0_33::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::from_item;
 /// #
@@ -68,7 +68,7 @@ where
 /// Interpret a [`Items`] as a `Vec<T>`.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_32::client::Client;
+/// # use __aws_sdk_dynamodb_0_33::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::from_items;
 /// #

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,11 +102,11 @@
 //!
 //! ```toml
 //! [dependencies]
-//! serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_31"] }
+//! serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_32"] }
 //! ```
 //!
-//! See [`aws_sdk_dynamodb_0_31`] for examples and more information. See
-//! [`aws_sdk_dynamodbstreams_0_31`] for DynamoDb streams support.
+//! See [`aws_sdk_dynamodb_0_32`] for examples and more information. See
+//! [`aws_sdk_dynamodbstreams_0_32`] for DynamoDb streams support.
 //!
 //! ## aws_lambda_events support
 //!
@@ -514,6 +514,16 @@ aws_sdk_macro!(
     config_version = "0.56",
 );
 
+aws_sdk_macro!(
+    feature = "aws-sdk-dynamodb+0_32",
+    crate_name = __aws_sdk_dynamodb_0_32,
+    mod_name = aws_sdk_dynamodb_0_32,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_32::types::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_32::primitives::Blob,
+    aws_version = "0.32",
+    config_version = "0.56",
+);
+
 aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_8",
     crate_name = __aws_sdk_dynamodbstreams_0_8,
@@ -719,6 +729,15 @@ aws_sdk_streams_macro!(
     attribute_value_path = ::__aws_sdk_dynamodbstreams_0_31::types::AttributeValue,
     blob_path = ::__aws_sdk_dynamodbstreams_0_31::primitives::Blob,
     aws_version = "0.31",
+);
+
+aws_sdk_streams_macro!(
+    feature = "aws-sdk-dynamodbstreams+0_32",
+    crate_name = __aws_sdk_dynamodbstreams_0_32,
+    mod_name = aws_sdk_dynamodbstreams_0_32,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_32::types::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_32::primitives::Blob,
+    aws_version = "0.32",
 );
 
 rusoto_macro!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,11 +102,11 @@
 //!
 //! ```toml
 //! [dependencies]
-//! serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_32"] }
+//! serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_33"] }
 //! ```
 //!
-//! See [`aws_sdk_dynamodb_0_32`] for examples and more information. See
-//! [`aws_sdk_dynamodbstreams_0_32`] for DynamoDb streams support.
+//! See [`aws_sdk_dynamodb_0_33`] for examples and more information. See
+//! [`aws_sdk_dynamodbstreams_0_33`] for DynamoDb streams support.
 //!
 //! ## aws_lambda_events support
 //!
@@ -524,6 +524,16 @@ aws_sdk_macro!(
     config_version = "0.56",
 );
 
+aws_sdk_macro!(
+    feature = "aws-sdk-dynamodb+0_33",
+    crate_name = __aws_sdk_dynamodb_0_33,
+    mod_name = aws_sdk_dynamodb_0_33,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_33::types::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_33::primitives::Blob,
+    aws_version = "0.33",
+    config_version = "0.56",
+);
+
 aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_8",
     crate_name = __aws_sdk_dynamodbstreams_0_8,
@@ -738,6 +748,15 @@ aws_sdk_streams_macro!(
     attribute_value_path = ::__aws_sdk_dynamodbstreams_0_32::types::AttributeValue,
     blob_path = ::__aws_sdk_dynamodbstreams_0_32::primitives::Blob,
     aws_version = "0.32",
+);
+
+aws_sdk_streams_macro!(
+    feature = "aws-sdk-dynamodbstreams+0_33",
+    crate_name = __aws_sdk_dynamodbstreams_0_33,
+    mod_name = aws_sdk_dynamodbstreams_0_33,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_33::types::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_33::primitives::Blob,
+    aws_version = "0.33",
 );
 
 rusoto_macro!(

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -27,7 +27,7 @@ use serializer_tuple_variant::SerializerTupleVariant;
 ///
 /// ```no_run
 /// use serde_dynamo::to_attribute_value;
-/// # use __aws_sdk_dynamodb_0_31::client::Client;
+/// # use __aws_sdk_dynamodb_0_32::client::Client;
 /// # use std::collections::HashMap;
 /// #
 /// # async fn get(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -50,7 +50,7 @@ use serializer_tuple_variant::SerializerTupleVariant;
 ///
 /// ```no_run
 /// use serde_dynamo::to_attribute_value;
-/// # use __aws_sdk_dynamodb_0_31::client::Client;
+/// # use __aws_sdk_dynamodb_0_32::client::Client;
 /// # use std::collections::HashMap;
 /// #
 /// # async fn query(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -94,7 +94,7 @@ where
 /// This is frequently used when serializing an entire data structure to be sent to DynamoDB.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_31::client::Client;
+/// # use __aws_sdk_dynamodb_0_32::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::to_item;
 /// #

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -27,7 +27,7 @@ use serializer_tuple_variant::SerializerTupleVariant;
 ///
 /// ```no_run
 /// use serde_dynamo::to_attribute_value;
-/// # use __aws_sdk_dynamodb_0_32::client::Client;
+/// # use __aws_sdk_dynamodb_0_33::client::Client;
 /// # use std::collections::HashMap;
 /// #
 /// # async fn get(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -50,7 +50,7 @@ use serializer_tuple_variant::SerializerTupleVariant;
 ///
 /// ```no_run
 /// use serde_dynamo::to_attribute_value;
-/// # use __aws_sdk_dynamodb_0_32::client::Client;
+/// # use __aws_sdk_dynamodb_0_33::client::Client;
 /// # use std::collections::HashMap;
 /// #
 /// # async fn query(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -94,7 +94,7 @@ where
 /// This is frequently used when serializing an entire data structure to be sent to DynamoDB.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_32::client::Client;
+/// # use __aws_sdk_dynamodb_0_33::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::to_item;
 /// #


### PR DESCRIPTION
Would be great to figure out some more "transparent" way of handling version iteratively in future. But my experience with Cargo is yet very limited.