### PR TITLE
Support deserializing structs from lists

### DIFF
--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -289,7 +289,11 @@ impl<'de> de::Deserializer<'de> for Deserializer {
     where
         V: Visitor<'de>,
     {
-        self.deserialize_map(visitor)
+        if let AttributeValue::L(_) = self.input {
+            self.deserialize_seq(visitor)
+        } else {
+            self.deserialize_map(visitor)
+        }
     }
 
     fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>


### PR DESCRIPTION
`serde` and `serde_json` have support for deserializing structs and
adjacently-tagged enums from sequences. I had no idea!

```rust
#[derive(serde::Deserialize)]
struct Person {
    name: String,
    age: u8,
}

let input = r#"["Arthur Dent", 42]"#;

let person: Person = serde_json::from_str(input).unwrap();
assert_eq!(person.name, "Arthur Dent");
assert_eq!(person.age, 42);
```

Fixes #87
