### PR TITLE
Support for aws-sdk-dynamodb 0.37.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ __aws_sdk_dynamodb_0_33 = { package = "aws-sdk-dynamodb", version = "0.33", defa
 __aws_sdk_dynamodb_0_34 = { package = "aws-sdk-dynamodb", version = "0.34", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_35 = { package = "aws-sdk-dynamodb", version = "0.35", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_36 = { package = "aws-sdk-dynamodb", version = "0.36", default-features = false, optional = true }
+__aws_sdk_dynamodb_0_37 = { package = "aws-sdk-dynamodb", version = "0.37", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_8 = { package = "aws-sdk-dynamodbstreams", version = "0.8", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_9 = { package = "aws-sdk-dynamodbstreams", version = "0.9", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_10 = { package = "aws-sdk-dynamodbstreams", version = "0.10", default-features = false, optional = true }
@@ -71,6 +72,7 @@ __aws_sdk_dynamodbstreams_0_33 = { package = "aws-sdk-dynamodbstreams", version 
 __aws_sdk_dynamodbstreams_0_34 = { package = "aws-sdk-dynamodbstreams", version = "0.34", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_35 = { package = "aws-sdk-dynamodbstreams", version = "0.35", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_36 = { package = "aws-sdk-dynamodbstreams", version = "0.36", default-features = false, optional = true }
+__aws_sdk_dynamodbstreams_0_37 = { package = "aws-sdk-dynamodbstreams", version = "0.37", default-features = false, optional = true }
 __rusoto_dynamodb_0_46 = { package = "rusoto_dynamodb", version = "0.46", default-features = false, optional = true }
 __rusoto_dynamodb_0_47 = { package = "rusoto_dynamodb", version = "0.47", default-features = false, optional = true }
 __rusoto_dynamodb_0_48 = { package = "rusoto_dynamodb", version = "0.48", default-features = false, optional = true }
@@ -116,6 +118,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodb+0_34" = ["__aws_sdk_dynamodb_0_34"]
 "aws-sdk-dynamodb+0_35" = ["__aws_sdk_dynamodb_0_35"]
 "aws-sdk-dynamodb+0_36" = ["__aws_sdk_dynamodb_0_36"]
+"aws-sdk-dynamodb+0_37" = ["__aws_sdk_dynamodb_0_37"]
 "aws-sdk-dynamodbstreams+0_8" = ["__aws_sdk_dynamodbstreams_0_8"]
 "aws-sdk-dynamodbstreams+0_9" = ["__aws_sdk_dynamodbstreams_0_9"]
 "aws-sdk-dynamodbstreams+0_10" = ["__aws_sdk_dynamodbstreams_0_10"]
@@ -144,6 +147,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodbstreams+0_34" = ["__aws_sdk_dynamodbstreams_0_34"]
 "aws-sdk-dynamodbstreams+0_35" = ["__aws_sdk_dynamodbstreams_0_35"]
 "aws-sdk-dynamodbstreams+0_36" = ["__aws_sdk_dynamodbstreams_0_36"]
+"aws-sdk-dynamodbstreams+0_37" = ["__aws_sdk_dynamodbstreams_0_37"]
 "rusoto_dynamodb+0_46" = ["__rusoto_dynamodb_0_46"]
 "rusoto_dynamodb+0_47" = ["__rusoto_dynamodb_0_47"]
 "rusoto_dynamodb+0_48" = ["__rusoto_dynamodb_0_48"]

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -32,7 +32,7 @@ where
 /// Interpret an [`Item`] as an instance of type `T`.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_36::client::Client;
+/// # use __aws_sdk_dynamodb_0_37::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::from_item;
 /// #
@@ -68,7 +68,7 @@ where
 /// Interpret a [`Items`] as a `Vec<T>`.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_36::client::Client;
+/// # use __aws_sdk_dynamodb_0_37::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::from_items;
 /// #

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,11 +102,11 @@
 //!
 //! ```toml
 //! [dependencies]
-//! serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_36"] }
+//! serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_37"] }
 //! ```
 //!
-//! See [`aws_sdk_dynamodb_0_36`] for examples and more information. See
-//! [`aws_sdk_dynamodbstreams_0_36`] for DynamoDb streams support.
+//! See [`aws_sdk_dynamodb_0_37`] for examples and more information. See
+//! [`aws_sdk_dynamodbstreams_0_37`] for DynamoDb streams support.
 //!
 //! ## aws_lambda_events support
 //!
@@ -564,6 +564,16 @@ aws_sdk_macro!(
     config_version = "0.57",
 );
 
+aws_sdk_macro!(
+    feature = "aws-sdk-dynamodb+0_37",
+    crate_name = __aws_sdk_dynamodb_0_37,
+    mod_name = aws_sdk_dynamodb_0_37,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_37::types::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_37::primitives::Blob,
+    aws_version = "0.37",
+    config_version = "0.100",
+);
+
 aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_8",
     crate_name = __aws_sdk_dynamodbstreams_0_8,
@@ -814,6 +824,15 @@ aws_sdk_streams_macro!(
     attribute_value_path = ::__aws_sdk_dynamodbstreams_0_36::types::AttributeValue,
     blob_path = ::__aws_sdk_dynamodbstreams_0_36::primitives::Blob,
     aws_version = "0.36",
+);
+
+aws_sdk_streams_macro!(
+    feature = "aws-sdk-dynamodbstreams+0_37",
+    crate_name = __aws_sdk_dynamodbstreams_0_37,
+    mod_name = aws_sdk_dynamodbstreams_0_37,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_37::types::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_37::primitives::Blob,
+    aws_version = "0.37",
 );
 
 rusoto_macro!(

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -27,7 +27,7 @@ use serializer_tuple_variant::SerializerTupleVariant;
 ///
 /// ```no_run
 /// use serde_dynamo::to_attribute_value;
-/// # use __aws_sdk_dynamodb_0_36::client::Client;
+/// # use __aws_sdk_dynamodb_0_37::client::Client;
 /// # use std::collections::HashMap;
 /// #
 /// # async fn get(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -50,7 +50,7 @@ use serializer_tuple_variant::SerializerTupleVariant;
 ///
 /// ```no_run
 /// use serde_dynamo::to_attribute_value;
-/// # use __aws_sdk_dynamodb_0_36::client::Client;
+/// # use __aws_sdk_dynamodb_0_37::client::Client;
 /// # use std::collections::HashMap;
 /// #
 /// # async fn query(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -94,7 +94,7 @@ where
 /// This is frequently used when serializing an entire data structure to be sent to DynamoDB.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_36::client::Client;
+/// # use __aws_sdk_dynamodb_0_37::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::to_item;
 /// #


### PR DESCRIPTION
Adds the latest AWS SDK DynamoDB version.

Note that `aws-config` jumped from 0.57 to 0.100 as part of https://github.com/awslabs/aws-sdk-rust/commit/12b5f6c4442e9dc939627e36ae3246fded9a7e51. I tried to find a justification for the jump but couldn't find the commits listed in the rollup commit, and didn't know where else to look for more information.