### PR TITLE
support for version 0.39 of aws-sdk-dynamodb / aws-sdk-dynamodbstreams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ __aws_sdk_dynamodb_0_35 = { package = "aws-sdk-dynamodb", version = "0.35", defa
 __aws_sdk_dynamodb_0_36 = { package = "aws-sdk-dynamodb", version = "0.36", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_37 = { package = "aws-sdk-dynamodb", version = "0.37", default-features = false, optional = true }
 __aws_sdk_dynamodb_0_38 = { package = "aws-sdk-dynamodb", version = "0.38", default-features = false, optional = true }
+__aws_sdk_dynamodb_0_39 = { package = "aws-sdk-dynamodb", version = "0.39", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_8 = { package = "aws-sdk-dynamodbstreams", version = "0.8", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_9 = { package = "aws-sdk-dynamodbstreams", version = "0.9", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_10 = { package = "aws-sdk-dynamodbstreams", version = "0.10", default-features = false, optional = true }
@@ -75,6 +76,7 @@ __aws_sdk_dynamodbstreams_0_35 = { package = "aws-sdk-dynamodbstreams", version 
 __aws_sdk_dynamodbstreams_0_36 = { package = "aws-sdk-dynamodbstreams", version = "0.36", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_37 = { package = "aws-sdk-dynamodbstreams", version = "0.37", default-features = false, optional = true }
 __aws_sdk_dynamodbstreams_0_38 = { package = "aws-sdk-dynamodbstreams", version = "0.38", default-features = false, optional = true }
+__aws_sdk_dynamodbstreams_0_39 = { package = "aws-sdk-dynamodbstreams", version = "0.39", default-features = false, optional = true }
 __rusoto_dynamodb_0_46 = { package = "rusoto_dynamodb", version = "0.46", default-features = false, optional = true }
 __rusoto_dynamodb_0_47 = { package = "rusoto_dynamodb", version = "0.47", default-features = false, optional = true }
 __rusoto_dynamodb_0_48 = { package = "rusoto_dynamodb", version = "0.48", default-features = false, optional = true }
@@ -122,6 +124,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodb+0_36" = ["__aws_sdk_dynamodb_0_36"]
 "aws-sdk-dynamodb+0_37" = ["__aws_sdk_dynamodb_0_37"]
 "aws-sdk-dynamodb+0_38" = ["__aws_sdk_dynamodb_0_38"]
+"aws-sdk-dynamodb+0_39" = ["__aws_sdk_dynamodb_0_39"]
 "aws-sdk-dynamodbstreams+0_8" = ["__aws_sdk_dynamodbstreams_0_8"]
 "aws-sdk-dynamodbstreams+0_9" = ["__aws_sdk_dynamodbstreams_0_9"]
 "aws-sdk-dynamodbstreams+0_10" = ["__aws_sdk_dynamodbstreams_0_10"]
@@ -152,6 +155,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 "aws-sdk-dynamodbstreams+0_36" = ["__aws_sdk_dynamodbstreams_0_36"]
 "aws-sdk-dynamodbstreams+0_37" = ["__aws_sdk_dynamodbstreams_0_37"]
 "aws-sdk-dynamodbstreams+0_38" = ["__aws_sdk_dynamodbstreams_0_38"]
+"aws-sdk-dynamodbstreams+0_39" = ["__aws_sdk_dynamodbstreams_0_39"]
 "rusoto_dynamodb+0_46" = ["__rusoto_dynamodb_0_46"]
 "rusoto_dynamodb+0_47" = ["__rusoto_dynamodb_0_47"]
 "rusoto_dynamodb+0_48" = ["__rusoto_dynamodb_0_48"]

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -32,7 +32,7 @@ where
 /// Interpret an [`Item`] as an instance of type `T`.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_38::client::Client;
+/// # use __aws_sdk_dynamodb_0_39::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::from_item;
 /// #
@@ -68,7 +68,7 @@ where
 /// Interpret a [`Items`] as a `Vec<T>`.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_38::client::Client;
+/// # use __aws_sdk_dynamodb_0_39::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::from_items;
 /// #

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,8 @@
 //! serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+0_38"] }
 //! ```
 //!
-//! See [`aws_sdk_dynamodb_0_38`] for examples and more information. See
-//! [`aws_sdk_dynamodbstreams_0_38`] for DynamoDb streams support.
+//! See [`aws_sdk_dynamodb_0_39`] for examples and more information. See
+//! [`aws_sdk_dynamodbstreams_0_39`] for DynamoDb streams support.
 //!
 //! ## aws_lambda_events support
 //!
@@ -584,6 +584,16 @@ aws_sdk_macro!(
     config_version = "0.101",
 );
 
+aws_sdk_macro!(
+    feature = "aws-sdk-dynamodb+0_39",
+    crate_name = __aws_sdk_dynamodb_0_39,
+    mod_name = aws_sdk_dynamodb_0_39,
+    attribute_value_path = ::__aws_sdk_dynamodb_0_39::types::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodb_0_39::primitives::Blob,
+    aws_version = "0.39",
+    config_version = "1.0",
+);
+
 aws_sdk_streams_macro!(
     feature = "aws-sdk-dynamodbstreams+0_8",
     crate_name = __aws_sdk_dynamodbstreams_0_8,
@@ -852,6 +862,15 @@ aws_sdk_streams_macro!(
     attribute_value_path = ::__aws_sdk_dynamodbstreams_0_38::types::AttributeValue,
     blob_path = ::__aws_sdk_dynamodbstreams_0_38::primitives::Blob,
     aws_version = "0.38",
+);
+
+aws_sdk_streams_macro!(
+    feature = "aws-sdk-dynamodbstreams+0_39",
+    crate_name = __aws_sdk_dynamodbstreams_0_39,
+    mod_name = aws_sdk_dynamodbstreams_0_39,
+    attribute_value_path = ::__aws_sdk_dynamodbstreams_0_39::types::AttributeValue,
+    blob_path = ::__aws_sdk_dynamodbstreams_0_39::primitives::Blob,
+    aws_version = "0.39",
 );
 
 rusoto_macro!(

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -27,7 +27,7 @@ use serializer_tuple_variant::SerializerTupleVariant;
 ///
 /// ```no_run
 /// use serde_dynamo::to_attribute_value;
-/// # use __aws_sdk_dynamodb_0_38::client::Client;
+/// # use __aws_sdk_dynamodb_0_39::client::Client;
 /// # use std::collections::HashMap;
 /// #
 /// # async fn get(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -50,7 +50,7 @@ use serializer_tuple_variant::SerializerTupleVariant;
 ///
 /// ```no_run
 /// use serde_dynamo::to_attribute_value;
-/// # use __aws_sdk_dynamodb_0_38::client::Client;
+/// # use __aws_sdk_dynamodb_0_39::client::Client;
 /// # use std::collections::HashMap;
 /// #
 /// # async fn query(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -94,7 +94,7 @@ where
 /// This is frequently used when serializing an entire data structure to be sent to DynamoDB.
 ///
 /// ```no_run
-/// # use __aws_sdk_dynamodb_0_38::client::Client;
+/// # use __aws_sdk_dynamodb_0_39::client::Client;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use serde_dynamo::to_item;
 /// #


### PR DESCRIPTION
Add support for version 0.39 of AWS SDKs gated by crate features `aws-sdk-dynamodb+0_39` and `aws-sdk-dynamodbstreams+0_39`