### PR TITLE
Depend on `serde_core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,11 +86,14 @@ __rusoto_dynamodbstreams_0_46 = { package = "rusoto_dynamodbstreams", version = 
 __rusoto_dynamodbstreams_0_47 = { package = "rusoto_dynamodbstreams", version = "0.47", default-features = false, optional = true }
 __rusoto_dynamodbstreams_0_48 = { package = "rusoto_dynamodbstreams", version = "0.48", default-features = false, optional = true }
 base64 = "0.21.0"
-serde = "1"
+serde_core = "1.0.220"
 
 __rusoto_core_0_46_crate = { package = "rusoto_core", version = "0.46", default-features = false, features = ["rustls"], optional = true }
 __rusoto_core_0_47_crate = { package = "rusoto_core", version = "0.47", default-features = false, features = ["rustls"], optional = true }
 __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-features = false, features = ["rustls"], optional = true }
+
+[target.'cfg(any())'.dependencies]
+serde = { version = "1.0.220", default-features = false }
 
 [features]
 "aws_lambda_events+0_6" = ["__aws_lambda_events_0_6"]
@@ -170,6 +173,7 @@ __rusoto_core_0_48_crate = { package = "rusoto_core", version = "0.48", default-
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 serde_bytes = "0.11"
+serde = "1"
 serde_derive = "1"
 serde_json = "1"
 

--- a/src/attribute_value.rs
+++ b/src/attribute_value.rs
@@ -82,12 +82,12 @@ pub enum AttributeValue {
     Bs(Vec<Vec<u8>>),
 }
 
-impl serde::Serialize for AttributeValue {
+impl serde_core::Serialize for AttributeValue {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
-        use serde::ser::SerializeMap;
+        use serde_core::ser::SerializeMap;
 
         match self {
             AttributeValue::N(inner) => {
@@ -148,13 +148,13 @@ impl serde::Serialize for AttributeValue {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for AttributeValue {
+impl<'de> serde_core::Deserialize<'de> for AttributeValue {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         struct Visitor;
-        impl<'de> serde::de::Visitor<'de> for Visitor {
+        impl<'de> serde_core::de::Visitor<'de> for Visitor {
             type Value = AttributeValue;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -163,9 +163,9 @@ impl<'de> serde::Deserialize<'de> for AttributeValue {
 
             fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
             where
-                A: serde::de::MapAccess<'de>,
+                A: serde_core::de::MapAccess<'de>,
             {
-                use serde::de::Error;
+                use serde_core::de::Error;
 
                 let first_key: String = match map.next_key()? {
                     Some(key) => key,
@@ -227,19 +227,19 @@ impl<'de> serde::Deserialize<'de> for AttributeValue {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for Item {
+impl<'de> serde_core::Deserialize<'de> for Item {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         HashMap::deserialize(deserializer).map(Item)
     }
 }
 
-impl serde::Serialize for Item {
+impl serde_core::Serialize for Item {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         self.0.serialize(serializer)
     }

--- a/src/binary_set.rs
+++ b/src/binary_set.rs
@@ -68,8 +68,8 @@ pub(crate) fn should_serialize_as_binary_set(name: &str) -> bool {
 /// * the sequence contains any value that is not a binary
 pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
-    T: serde::Serialize,
-    S: serde::Serializer,
+    T: serde_core::Serialize,
+    S: serde_core::Serializer,
 {
     serializer.serialize_newtype_struct(NEWTYPE_SYMBOL, &value)
 }
@@ -77,8 +77,8 @@ where
 /// Deserializes the given value as a set
 pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
-    T: serde::Deserialize<'de>,
-    D: serde::Deserializer<'de>,
+    T: serde_core::Deserialize<'de>,
+    D: serde_core::Deserializer<'de>,
 {
     T::deserialize(deserializer)
 }
@@ -107,13 +107,13 @@ where
 /// ```
 pub struct BinarySet<T>(pub T);
 
-impl<T> serde::Serialize for BinarySet<T>
+impl<T> serde_core::Serialize for BinarySet<T>
 where
-    T: serde::Serialize,
+    T: serde_core::Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         serializer.serialize_newtype_struct(NEWTYPE_SYMBOL, &self.0)
     }

--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -8,7 +8,7 @@ use super::{
     },
     AttributeValue, Error, ErrorImpl, Result,
 };
-use serde::de::{self, IntoDeserializer, Visitor};
+use serde_core::de::{self, IntoDeserializer, Visitor};
 
 /// A structure that deserializes [`AttributeValue`]s into Rust values.
 #[derive(Debug)]

--- a/src/de/deserializer_bytes.rs
+++ b/src/de/deserializer_bytes.rs
@@ -1,6 +1,6 @@
 use super::{Error, Result};
-use serde::de::{self, Visitor};
-use serde::forward_to_deserialize_any;
+use serde_core::de::{self, Visitor};
+use serde_core::forward_to_deserialize_any;
 
 pub struct DeserializerBytes<T> {
     input: T,

--- a/src/de/deserializer_enum.rs
+++ b/src/de/deserializer_enum.rs
@@ -1,5 +1,5 @@
 use super::{AttributeValue, Deserializer, Error, ErrorImpl, Result};
-use serde::de::{
+use serde_core::de::{
     DeserializeSeed, Deserializer as _, EnumAccess, IntoDeserializer, VariantAccess, Visitor,
 };
 use std::collections::HashMap;

--- a/src/de/deserializer_map.rs
+++ b/src/de/deserializer_map.rs
@@ -1,5 +1,5 @@
 use super::{AttributeValue, Deserializer, Error, ErrorImpl, Result};
-use serde::{
+use serde_core::{
     de::{self, DeserializeSeed, MapAccess, Visitor},
     forward_to_deserialize_any,
 };

--- a/src/de/deserializer_number.rs
+++ b/src/de/deserializer_number.rs
@@ -1,6 +1,6 @@
 use super::{Error, ErrorImpl, Result};
-use serde::de::{self, Visitor};
-use serde::forward_to_deserialize_any;
+use serde_core::de::{self, Visitor};
+use serde_core::forward_to_deserialize_any;
 
 pub struct DeserializerNumber {
     input: String,

--- a/src/de/deserializer_seq.rs
+++ b/src/de/deserializer_seq.rs
@@ -1,7 +1,7 @@
 use super::deserializer_bytes::DeserializerBytes;
 use super::deserializer_number::DeserializerNumber;
 use super::{AttributeValue, Deserializer, Error, Result};
-use serde::de::{DeserializeSeed, IntoDeserializer, SeqAccess};
+use serde_core::de::{DeserializeSeed, IntoDeserializer, SeqAccess};
 
 pub struct DeserializerSeq {
     iter: std::vec::IntoIter<AttributeValue>,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,6 +1,6 @@
 use super::AttributeValue;
 use crate::{error::ErrorImpl, Error, Item, Items, Result};
-use serde::Deserialize;
+use serde_core::Deserialize;
 use std::collections::HashMap;
 
 mod deserializer;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use serde::{de, ser};
+use serde_core::{de, ser};
 use std::fmt::{self, Display};
 
 /// This type represents all possible errors that can occur when serializing or deserializing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,8 @@
 //! change streams.
 //!
 //! However, in very rare cases, you may need to convert the DynamoDB JSON yourself. In those cases,
-//! both [Item] and [AttributeValue] implement [serde::Serialize] and [serde::Deserialize].
+//! both [Item] and [AttributeValue] implement [serde_core::Serialize] and
+//! [serde_core::Deserialize].
 //!
 //! ```
 //! # use serde_dynamo::{AttributeValue, Item};

--- a/src/macros/aws_lambda_events.rs
+++ b/src/macros/aws_lambda_events.rs
@@ -58,7 +58,7 @@ macro_rules! aws_lambda_events_macro {
             /// [`serde_dynamo`-specific AttributeValue](crate::AttributeValue).
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_attribute_value(value)
             }
@@ -68,7 +68,7 @@ macro_rules! aws_lambda_events_macro {
             /// [`serde_dynamo`-specific Item](crate::Item).
             pub fn to_item<T>(value: T) -> Result<std::collections::HashMap<String, AttributeValue>>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_item(value)
             }
@@ -78,7 +78,7 @@ macro_rules! aws_lambda_events_macro {
             /// [`serde_dynamo`-specific AttributeValue](crate::AttributeValue).
             pub fn from_attribute_value<'a, T>(attribute_value: AttributeValue) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_attribute_value(attribute_value)
             }
@@ -90,7 +90,7 @@ macro_rules! aws_lambda_events_macro {
                 item: std::collections::HashMap<String, AttributeValue>,
             ) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_item(item)
             }
@@ -102,7 +102,7 @@ macro_rules! aws_lambda_events_macro {
                 items: Vec<std::collections::HashMap<String, AttributeValue>>,
             ) -> Result<Vec<T>>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_items(items)
             }

--- a/src/macros/aws_sdk.rs
+++ b/src/macros/aws_sdk.rs
@@ -221,7 +221,7 @@ macro_rules! aws_sdk_macro {
             /// `AV`.
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_attribute_value(value)
             }
@@ -233,7 +233,7 @@ macro_rules! aws_sdk_macro {
             /// `AV`.
             pub fn to_item<T>(value: T) -> Result<std::collections::HashMap<String, AttributeValue>>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_item(value)
             }
@@ -245,7 +245,7 @@ macro_rules! aws_sdk_macro {
             /// `AV`.
             pub fn from_attribute_value<'a, T>(attribute_value: AttributeValue) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_attribute_value(attribute_value)
             }
@@ -259,7 +259,7 @@ macro_rules! aws_sdk_macro {
                 item: std::collections::HashMap<String, AttributeValue>,
             ) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_item(item)
             }
@@ -273,7 +273,7 @@ macro_rules! aws_sdk_macro {
                 items: Vec<std::collections::HashMap<String, AttributeValue>>,
             ) -> Result<Vec<T>>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_items(items)
             }
@@ -289,7 +289,7 @@ macro_rules! aws_sdk_macro {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_attribute_value(value)
             }
@@ -297,7 +297,7 @@ macro_rules! aws_sdk_macro {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_item<T>(value: T) -> Result<std::collections::HashMap<String, AttributeValue>>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_item(value)
             }
@@ -305,7 +305,7 @@ macro_rules! aws_sdk_macro {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn from_attribute_value<'a, T>(attribute_value: AttributeValue) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_attribute_value(attribute_value)
             }
@@ -315,7 +315,7 @@ macro_rules! aws_sdk_macro {
                 item: std::collections::HashMap<String, AttributeValue>,
             ) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_item(item)
             }
@@ -325,7 +325,7 @@ macro_rules! aws_sdk_macro {
                 items: Vec<std::collections::HashMap<String, AttributeValue>>,
             ) -> Result<Vec<T>>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_items(items)
             }

--- a/src/macros/aws_sdk_before_0_35.rs
+++ b/src/macros/aws_sdk_before_0_35.rs
@@ -222,7 +222,7 @@ macro_rules! aws_sdk_macro_before_0_35 {
             /// `AV`.
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_attribute_value(value)
             }
@@ -234,7 +234,7 @@ macro_rules! aws_sdk_macro_before_0_35 {
             /// `AV`.
             pub fn to_item<T>(value: T) -> Result<std::collections::HashMap<String, AttributeValue>>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_item(value)
             }
@@ -246,7 +246,7 @@ macro_rules! aws_sdk_macro_before_0_35 {
             /// `AV`.
             pub fn from_attribute_value<'a, T>(attribute_value: AttributeValue) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_attribute_value(attribute_value)
             }
@@ -260,7 +260,7 @@ macro_rules! aws_sdk_macro_before_0_35 {
                 item: std::collections::HashMap<String, AttributeValue>,
             ) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_item(item)
             }
@@ -274,7 +274,7 @@ macro_rules! aws_sdk_macro_before_0_35 {
                 items: Vec<std::collections::HashMap<String, AttributeValue>>,
             ) -> Result<Vec<T>>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_items(items)
             }
@@ -290,7 +290,7 @@ macro_rules! aws_sdk_macro_before_0_35 {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_attribute_value(value)
             }
@@ -298,7 +298,7 @@ macro_rules! aws_sdk_macro_before_0_35 {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_item<T>(value: T) -> Result<std::collections::HashMap<String, AttributeValue>>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_item(value)
             }
@@ -306,7 +306,7 @@ macro_rules! aws_sdk_macro_before_0_35 {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn from_attribute_value<'a, T>(attribute_value: AttributeValue) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_attribute_value(attribute_value)
             }
@@ -316,7 +316,7 @@ macro_rules! aws_sdk_macro_before_0_35 {
                 item: std::collections::HashMap<String, AttributeValue>,
             ) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_item(item)
             }
@@ -326,7 +326,7 @@ macro_rules! aws_sdk_macro_before_0_35 {
                 items: Vec<std::collections::HashMap<String, AttributeValue>>,
             ) -> Result<Vec<T>>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_items(items)
             }

--- a/src/macros/aws_sdk_streams.rs
+++ b/src/macros/aws_sdk_streams.rs
@@ -70,7 +70,7 @@ macro_rules! aws_sdk_streams_macro {
             /// `AV`.
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_attribute_value(value)
             }
@@ -82,7 +82,7 @@ macro_rules! aws_sdk_streams_macro {
             /// `AV`.
             pub fn to_item<T>(value: T) -> Result<std::collections::HashMap<String, AttributeValue>>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_item(value)
             }
@@ -94,7 +94,7 @@ macro_rules! aws_sdk_streams_macro {
             /// `AV`.
             pub fn from_attribute_value<'a, T>(attribute_value: AttributeValue) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_attribute_value(attribute_value)
             }
@@ -108,7 +108,7 @@ macro_rules! aws_sdk_streams_macro {
                 item: std::collections::HashMap<String, AttributeValue>,
             ) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_item(item)
             }
@@ -122,7 +122,7 @@ macro_rules! aws_sdk_streams_macro {
                 items: Vec<std::collections::HashMap<String, AttributeValue>>,
             ) -> Result<Vec<T>>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_items(items)
             }
@@ -138,7 +138,7 @@ macro_rules! aws_sdk_streams_macro {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_attribute_value(value)
             }
@@ -146,7 +146,7 @@ macro_rules! aws_sdk_streams_macro {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_item<T>(value: T) -> Result<std::collections::HashMap<String, AttributeValue>>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_item(value)
             }
@@ -154,7 +154,7 @@ macro_rules! aws_sdk_streams_macro {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn from_attribute_value<'a, T>(attribute_value: AttributeValue) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_attribute_value(attribute_value)
             }
@@ -164,7 +164,7 @@ macro_rules! aws_sdk_streams_macro {
                 item: std::collections::HashMap<String, AttributeValue>,
             ) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_item(item)
             }
@@ -174,7 +174,7 @@ macro_rules! aws_sdk_streams_macro {
                 items: Vec<std::collections::HashMap<String, AttributeValue>>,
             ) -> Result<Vec<T>>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_items(items)
             }

--- a/src/macros/rusoto.rs
+++ b/src/macros/rusoto.rs
@@ -234,7 +234,7 @@ macro_rules! rusoto_macro {
             /// `AV`.
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_attribute_value(value)
             }
@@ -246,7 +246,7 @@ macro_rules! rusoto_macro {
             /// `AV`.
             pub fn to_item<T>(value: T) -> Result<std::collections::HashMap<String, AttributeValue>>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_item(value)
             }
@@ -258,7 +258,7 @@ macro_rules! rusoto_macro {
             /// `AV`.
             pub fn from_attribute_value<'a, T>(attribute_value: AttributeValue) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_attribute_value(attribute_value)
             }
@@ -272,7 +272,7 @@ macro_rules! rusoto_macro {
                 item: std::collections::HashMap<String, AttributeValue>,
             ) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_item(item)
             }
@@ -286,7 +286,7 @@ macro_rules! rusoto_macro {
                 items: Vec<std::collections::HashMap<String, AttributeValue>>,
             ) -> Result<Vec<T>>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_items(items)
             }
@@ -302,7 +302,7 @@ macro_rules! rusoto_macro {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_attribute_value(value)
             }
@@ -310,7 +310,7 @@ macro_rules! rusoto_macro {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_item<T>(value: T) -> Result<std::collections::HashMap<String, AttributeValue>>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_item(value)
             }
@@ -318,7 +318,7 @@ macro_rules! rusoto_macro {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn from_attribute_value<'a, T>(attribute_value: AttributeValue) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_attribute_value(attribute_value)
             }
@@ -328,7 +328,7 @@ macro_rules! rusoto_macro {
                 item: std::collections::HashMap<String, AttributeValue>,
             ) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_item(item)
             }
@@ -338,7 +338,7 @@ macro_rules! rusoto_macro {
                 items: Vec<std::collections::HashMap<String, AttributeValue>>,
             ) -> Result<Vec<T>>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_items(items)
             }

--- a/src/macros/rusoto_streams.rs
+++ b/src/macros/rusoto_streams.rs
@@ -64,7 +64,7 @@ macro_rules! rusoto_streams_macro {
             /// `AV`.
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_attribute_value(value)
             }
@@ -76,7 +76,7 @@ macro_rules! rusoto_streams_macro {
             /// `AV`.
             pub fn to_item<T>(value: T) -> Result<std::collections::HashMap<String, AttributeValue>>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_item(value)
             }
@@ -88,7 +88,7 @@ macro_rules! rusoto_streams_macro {
             /// `AV`.
             pub fn from_attribute_value<'a, T>(attribute_value: AttributeValue) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_attribute_value(attribute_value)
             }
@@ -102,7 +102,7 @@ macro_rules! rusoto_streams_macro {
                 item: std::collections::HashMap<String, AttributeValue>,
             ) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_item(item)
             }
@@ -116,7 +116,7 @@ macro_rules! rusoto_streams_macro {
                 items: Vec<std::collections::HashMap<String, AttributeValue>>,
             ) -> Result<Vec<T>>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_items(items)
             }
@@ -132,7 +132,7 @@ macro_rules! rusoto_streams_macro {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_attribute_value<T>(value: T) -> Result<AttributeValue>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_attribute_value(value)
             }
@@ -140,7 +140,7 @@ macro_rules! rusoto_streams_macro {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn to_item<T>(value: T) -> Result<std::collections::HashMap<String, AttributeValue>>
             where
-                T: serde::ser::Serialize,
+                T: serde_core::ser::Serialize,
             {
                 crate::ser::to_item(value)
             }
@@ -148,7 +148,7 @@ macro_rules! rusoto_streams_macro {
             #[deprecated(since = "4.0.0", note = "The double-underscore on the mod name is no longer necessary")]
             pub fn from_attribute_value<'a, T>(attribute_value: AttributeValue) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_attribute_value(attribute_value)
             }
@@ -158,7 +158,7 @@ macro_rules! rusoto_streams_macro {
                 item: std::collections::HashMap<String, AttributeValue>,
             ) -> Result<T>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_item(item)
             }
@@ -168,7 +168,7 @@ macro_rules! rusoto_streams_macro {
                 items: Vec<std::collections::HashMap<String, AttributeValue>>,
             ) -> Result<Vec<T>>
             where
-                T: serde::de::Deserialize<'a>,
+                T: serde_core::de::Deserialize<'a>,
             {
                 crate::de::from_items(items)
             }

--- a/src/number_set.rs
+++ b/src/number_set.rs
@@ -64,8 +64,8 @@ pub(crate) fn should_serialize_as_numbers_set(name: &str) -> bool {
 /// * the sequence contains any value that is not a number
 pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
-    T: serde::Serialize,
-    S: serde::Serializer,
+    T: serde_core::Serialize,
+    S: serde_core::Serializer,
 {
     serializer.serialize_newtype_struct(NEWTYPE_SYMBOL, &value)
 }
@@ -73,8 +73,8 @@ where
 /// Deserializes the given value as a set
 pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
-    T: serde::Deserialize<'de>,
-    D: serde::Deserializer<'de>,
+    T: serde_core::Deserialize<'de>,
+    D: serde_core::Deserializer<'de>,
 {
     T::deserialize(deserializer)
 }
@@ -102,13 +102,13 @@ where
 /// ```
 pub struct NumberSet<T>(pub T);
 
-impl<T> serde::Serialize for NumberSet<T>
+impl<T> serde_core::Serialize for NumberSet<T>
 where
-    T: serde::Serialize,
+    T: serde_core::Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         serializer.serialize_newtype_struct(NEWTYPE_SYMBOL, &self.0)
     }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,6 +1,6 @@
 use super::AttributeValue;
 use crate::{error::ErrorImpl, Error, Item, Result};
-use serde::Serialize;
+use serde_core::Serialize;
 
 mod serializer;
 mod serializer_map;

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -2,7 +2,7 @@ use super::{
     AttributeValue, Error, SerializerMap, SerializerSeq, SerializerStruct, SerializerStructVariant,
     SerializerTupleVariant,
 };
-use serde::{ser, Serialize};
+use serde_core::{ser, Serialize};
 use std::collections::HashMap;
 
 /// A structure for serializing Rust values into [`AttributeValue`]s.

--- a/src/ser/serializer_map.rs
+++ b/src/ser/serializer_map.rs
@@ -1,5 +1,5 @@
 use super::{AttributeValue, Error, ErrorImpl, Result, Serializer};
-use serde::{ser, Serialize};
+use serde_core::{ser, Serialize};
 use std::collections::HashMap;
 
 pub struct SerializerMap {

--- a/src/ser/serializer_seq.rs
+++ b/src/ser/serializer_seq.rs
@@ -1,5 +1,5 @@
 use super::{AttributeValue, Error, Result, Serializer};
-use serde::{ser, Serialize};
+use serde_core::{ser, Serialize};
 
 pub struct SerializerSeq {
     vec: Vec<AttributeValue>,

--- a/src/ser/serializer_struct.rs
+++ b/src/ser/serializer_struct.rs
@@ -1,5 +1,5 @@
 use super::{AttributeValue, Error, Result, Serializer};
-use serde::{ser, Serialize};
+use serde_core::{ser, Serialize};
 use std::collections::HashMap;
 
 pub struct SerializerStruct {

--- a/src/ser/serializer_struct_variant.rs
+++ b/src/ser/serializer_struct_variant.rs
@@ -1,5 +1,5 @@
 use super::{AttributeValue, Error, Result, Serializer};
-use serde::{ser, Serialize};
+use serde_core::{ser, Serialize};
 use std::collections::HashMap;
 
 pub struct SerializerStructVariant {

--- a/src/ser/serializer_tuple_variant.rs
+++ b/src/ser/serializer_tuple_variant.rs
@@ -1,5 +1,5 @@
 use super::{AttributeValue, Error, Result, Serializer};
-use serde::{ser, Serialize};
+use serde_core::{ser, Serialize};
 use std::collections::HashMap;
 
 pub struct SerializerTupleVariant {

--- a/src/string_set.rs
+++ b/src/string_set.rs
@@ -64,8 +64,8 @@ pub(crate) fn should_serialize_as_string_set(name: &str) -> bool {
 /// * the sequence contains any value that is not a string
 pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
-    T: serde::Serialize,
-    S: serde::Serializer,
+    T: serde_core::Serialize,
+    S: serde_core::Serializer,
 {
     serializer.serialize_newtype_struct(NEWTYPE_SYMBOL, &value)
 }
@@ -73,8 +73,8 @@ where
 /// Deserializes the given value as a set
 pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
-    T: serde::Deserialize<'de>,
-    D: serde::Deserializer<'de>,
+    T: serde_core::Deserialize<'de>,
+    D: serde_core::Deserializer<'de>,
 {
     T::deserialize(deserializer)
 }
@@ -102,13 +102,13 @@ where
 /// ```
 pub struct StringSet<T>(pub T);
 
-impl<T> serde::Serialize for StringSet<T>
+impl<T> serde_core::Serialize for StringSet<T>
 where
-    T: serde::Serialize,
+    T: serde_core::Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         serializer.serialize_newtype_struct(NEWTYPE_SYMBOL, &self.0)
     }


### PR DESCRIPTION
The serde team recently released a `serde_core` crate that allows crates
like this one to move forward in the dependency chain.

https://github.com/serde-rs/serde/pull/2608