### PR TITLE
Reworked `Error` to include the `AttributeValue` and path that failed to deserialize

### DIFF
--- a/src/binary_set.rs
+++ b/src/binary_set.rs
@@ -123,7 +123,13 @@ where
 pub(crate) fn convert_to_set(value: crate::AttributeValue) -> crate::Result<crate::AttributeValue> {
     let vals = match value {
         crate::AttributeValue::L(vals) => vals,
-        _ => return Err(crate::error::ErrorImpl::NotSetlike.into()),
+        _ => {
+            return Err(crate::error::Error::new(
+                crate::error::ErrorImpl::NotSetlike,
+                String::new(),
+                Some(value),
+            ))
+        }
     };
 
     let set = vals
@@ -132,7 +138,11 @@ pub(crate) fn convert_to_set(value: crate::AttributeValue) -> crate::Result<crat
             if let crate::AttributeValue::B(s) = v {
                 Ok(s)
             } else {
-                Err(crate::error::ErrorImpl::BinarySetExpectedType.into())
+                Err(crate::error::Error::new(
+                    crate::error::ErrorImpl::BinarySetExpectedType,
+                    String::new(),
+                    Some(v),
+                ))
             }
         })
         .collect::<Result<_, _>>()?;

--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -250,7 +250,7 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'a> {
     {
         match self.input {
             AttributeValue::S(s) => visitor.visit_enum(s.into_deserializer()),
-            AttributeValue::M(m) => visitor.visit_enum(DeserializerEnum::from_item(m, self.path)),
+            AttributeValue::M(m) => visitor.visit_enum(DeserializerEnum::from_item(m, &self.path)),
             _ => Err(self.error(ErrorImpl::ExpectedEnum)),
         }
     }

--- a/src/de/deserializer_enum.rs
+++ b/src/de/deserializer_enum.rs
@@ -6,11 +6,11 @@ use std::collections::HashMap;
 
 pub struct DeserializerEnum<'a> {
     input: HashMap<String, AttributeValue>,
-    path: ErrorPath<'a>,
+    path: &'a ErrorPath<'a>,
 }
 
 impl<'a> DeserializerEnum<'a> {
-    pub fn from_item(input: HashMap<String, AttributeValue>, path: ErrorPath<'a>) -> Self {
+    pub fn from_item(input: HashMap<String, AttributeValue>, path: &'a ErrorPath<'a>) -> Self {
         Self { input, path }
     }
 }
@@ -33,7 +33,7 @@ impl<'de, 'a> EnumAccess<'de> for DeserializerEnum<'a> {
         let (key, value) = self.input.into_iter().next().unwrap();
         let deserializer = DeserializerVariant::from_attribute_value(
             value,
-            ErrorPath::Enum(key.clone(), Box::new(self.path)),
+            ErrorPath::Enum(key.clone(), self.path),
         );
         let value = seed.deserialize(key.into_deserializer())?;
 

--- a/src/de/deserializer_number.rs
+++ b/src/de/deserializer_number.rs
@@ -1,6 +1,5 @@
-use crate::de::ErrorPath;
-
 use super::{Error, ErrorImpl, Result};
+use crate::{error::ErrorPath, AttributeValue};
 use serde_core::de::{self, Visitor};
 use serde_core::forward_to_deserialize_any;
 
@@ -25,27 +24,37 @@ impl<'a> DeserializerNumber<'a> {
             (Ok(i), _, _) => visitor.visit_i64(i),
             (_, Ok(u), _) => visitor.visit_u64(u),
             (_, _, Ok(f)) => visitor.visit_f64(f),
-            (Err(_), Err(_), Err(e)) => Err(Error::from_path(ErrorImpl::FailedToParseFloat(self.input, e), &self.path)),
+            (Err(_), Err(_), Err(e)) => Err(Error::from_path(
+                ErrorImpl::FailedToParseFloat(e),
+                &self.path,
+                AttributeValue::N(self.input),
+            )),
         }
     }
 }
 
 macro_rules! deserialize_int {
     ($self:expr, $visitor:expr, $ty:ty, $fn:ident) => {{
-        let n = $self
-            .input
-            .parse::<$ty>()
-            .map_err(|e| Error::from_path(ErrorImpl::FailedToParseInt($self.input, e), &$self.path))?;
+        let n = $self.input.parse::<$ty>().map_err(|e| {
+            Error::from_path(
+                ErrorImpl::FailedToParseInt(e),
+                &$self.path,
+                AttributeValue::N($self.input),
+            )
+        })?;
         $visitor.$fn(n)
     }};
 }
 
 macro_rules! deserialize_float {
     ($self:expr, $visitor:expr, $ty:ty, $fn:ident) => {{
-        let n = $self
-            .input
-            .parse::<$ty>()
-            .map_err(|e| Error::from_path(ErrorImpl::FailedToParseFloat($self.input, e), &$self.path))?;
+        let n = $self.input.parse::<$ty>().map_err(|e| {
+            Error::from_path(
+                ErrorImpl::FailedToParseFloat(e),
+                &$self.path,
+                AttributeValue::N($self.input),
+            )
+        })?;
         $visitor.$fn(n)
     }};
 }

--- a/src/de/deserializer_seq.rs
+++ b/src/de/deserializer_seq.rs
@@ -1,8 +1,7 @@
-use crate::de::ErrorPath;
-
 use super::deserializer_bytes::DeserializerBytes;
 use super::deserializer_number::DeserializerNumber;
 use super::{AttributeValue, Deserializer, Error, Result};
+use crate::error::ErrorPath;
 use serde_core::de::{DeserializeSeed, IntoDeserializer, SeqAccess};
 
 pub struct DeserializerSeq<'a> {

--- a/src/de/deserializer_seq.rs
+++ b/src/de/deserializer_seq.rs
@@ -1,29 +1,33 @@
+use crate::de::ErrorPath;
+
 use super::deserializer_bytes::DeserializerBytes;
 use super::deserializer_number::DeserializerNumber;
 use super::{AttributeValue, Deserializer, Error, Result};
 use serde_core::de::{DeserializeSeed, IntoDeserializer, SeqAccess};
 
-pub struct DeserializerSeq {
-    iter: std::vec::IntoIter<AttributeValue>,
+pub struct DeserializerSeq<'a> {
+    iter: std::iter::Enumerate<std::vec::IntoIter<AttributeValue>>,
+    path: ErrorPath<'a>,
 }
 
-impl DeserializerSeq {
-    pub fn from_vec(vec: Vec<AttributeValue>) -> Self {
+impl<'a> DeserializerSeq<'a> {
+    pub fn from_vec(vec: Vec<AttributeValue>, path: ErrorPath<'a>) -> Self {
         Self {
-            iter: vec.into_iter(),
+            iter: vec.into_iter().enumerate(),
+            path,
         }
     }
 }
 
-impl<'de> SeqAccess<'de> for DeserializerSeq {
+impl<'de, 'a> SeqAccess<'de> for DeserializerSeq<'a> {
     type Error = Error;
 
     fn next_element_seed<S>(&mut self, seed: S) -> Result<Option<S::Value>, Self::Error>
     where
         S: DeserializeSeed<'de>,
     {
-        if let Some(value) = self.iter.next() {
-            let de = Deserializer::from_attribute_value(value);
+        if let Some((i, value)) = self.iter.next() {
+            let de = Deserializer::from_attribute_value_path(value, ErrorPath::Elem(i, &self.path));
             seed.deserialize(de).map(Some)
         } else {
             Ok(None)
@@ -56,6 +60,7 @@ impl<'de> SeqAccess<'de> for DeserializerSeqStrings {
     {
         if let Some(value) = self.iter.next() {
             let de = value.into_deserializer();
+            // TODO: Add path
             seed.deserialize(de).map(Some)
         } else {
             Ok(None)
@@ -63,27 +68,29 @@ impl<'de> SeqAccess<'de> for DeserializerSeqStrings {
     }
 }
 
-pub struct DeserializerSeqNumbers {
-    iter: std::vec::IntoIter<String>,
+pub struct DeserializerSeqNumbers<'a> {
+    iter: std::iter::Enumerate<std::vec::IntoIter<String>>,
+    path: ErrorPath<'a>,
 }
 
-impl DeserializerSeqNumbers {
-    pub fn from_vec(vec: Vec<String>) -> Self {
+impl<'a> DeserializerSeqNumbers<'a> {
+    pub fn from_vec(vec: Vec<String>, path: ErrorPath<'a>) -> Self {
         Self {
-            iter: vec.into_iter(),
+            iter: vec.into_iter().enumerate(),
+            path,
         }
     }
 }
 
-impl<'de> SeqAccess<'de> for DeserializerSeqNumbers {
+impl<'de, 'a> SeqAccess<'de> for DeserializerSeqNumbers<'a> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
     where
         T: DeserializeSeed<'de>,
     {
-        if let Some(value) = self.iter.next() {
-            let de = DeserializerNumber::from_string(value);
+        if let Some((i, value)) = self.iter.next() {
+            let de = DeserializerNumber::from_string(value, ErrorPath::Elem(i, &self.path));
             seed.deserialize(de).map(Some)
         } else {
             Ok(None)

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,5 +1,8 @@
 use super::AttributeValue;
-use crate::{error::ErrorImpl, Error, Item, Items, Result};
+use crate::{
+    error::{ErrorImpl, ErrorPath},
+    Error, Item, Items, Result,
+};
 use serde_core::Deserialize;
 use std::collections::HashMap;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -190,18 +190,14 @@ pub(crate) enum ErrorPath<'a> {
     Root,
     Field(&'a str, &'a ErrorPath<'a>),
     Elem(usize, &'a ErrorPath<'a>),
-    Enum(String, Box<ErrorPath<'a>>),
+    Enum(String, &'a ErrorPath<'a>),
 }
 
 impl<'a> ErrorPath<'a> {
     pub(crate) fn visit_path_depth_first(&self, fun: &mut impl FnMut(&ErrorPath<'a>)) {
         match self {
             ErrorPath::Root => {}
-            ErrorPath::Field(_, path) | ErrorPath::Elem(_, path) => {
-                path.visit_path_depth_first(fun);
-                fun(self);
-            }
-            ErrorPath::Enum(_, path) => {
+            ErrorPath::Field(_, path) | ErrorPath::Elem(_, path) | ErrorPath::Enum(_, path) => {
                 path.visit_path_depth_first(fun);
                 fun(self);
             }

--- a/src/number_set.rs
+++ b/src/number_set.rs
@@ -118,7 +118,13 @@ where
 pub(crate) fn convert_to_set(value: crate::AttributeValue) -> crate::Result<crate::AttributeValue> {
     let vals = match value {
         crate::AttributeValue::L(vals) => vals,
-        _ => return Err(crate::error::ErrorImpl::NotSetlike.into()),
+        _ => {
+            return Err(crate::error::Error::new(
+                crate::error::ErrorImpl::NotSetlike,
+                String::new(),
+                Some(value),
+            ))
+        }
     };
 
     let set = vals
@@ -127,7 +133,11 @@ pub(crate) fn convert_to_set(value: crate::AttributeValue) -> crate::Result<crat
             if let crate::AttributeValue::N(s) = v {
                 Ok(s)
             } else {
-                Err(crate::error::ErrorImpl::NumberSetExpectedType.into())
+                Err(crate::error::Error::new(
+                    crate::error::ErrorImpl::NumberSetExpectedType,
+                    String::new(),
+                    Some(v),
+                ))
             }
         })
         .collect::<Result<_, _>>()?;

--- a/src/string_set.rs
+++ b/src/string_set.rs
@@ -118,7 +118,13 @@ where
 pub(crate) fn convert_to_set(value: crate::AttributeValue) -> crate::Result<crate::AttributeValue> {
     let vals = match value {
         crate::AttributeValue::L(vals) => vals,
-        _ => return Err(crate::error::ErrorImpl::NotSetlike.into()),
+        _ => {
+            return Err(crate::error::Error::new(
+                crate::error::ErrorImpl::NotSetlike,
+                String::new(),
+                Some(value),
+            ))
+        }
     };
 
     let set = vals
@@ -127,7 +133,11 @@ pub(crate) fn convert_to_set(value: crate::AttributeValue) -> crate::Result<crat
             if let crate::AttributeValue::S(s) = v {
                 Ok(s)
             } else {
-                Err(crate::error::ErrorImpl::StringSetExpectedType.into())
+                Err(crate::error::Error::new(
+                    crate::error::ErrorImpl::StringSetExpectedType,
+                    String::new(),
+                    Some(v),
+                ))
             }
         })
         .collect::<Result<_, _>>()?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -167,7 +167,7 @@ mod from_items {
         ];
 
         let err = from_items::<Items, User>(items.into()).unwrap_err();
-        assert_eq!(String::from("Expected num at '[1].age'"), err.to_string());
+        assert_eq!(String::from("Expected num at '[1].age'. Value: S(\"not a number\")"), err.to_string());
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -103,7 +103,7 @@ fn error_eq() {
 
 #[cfg(test)]
 mod from_items {
-    use crate::{error::ErrorImpl, from_items, to_attribute_value, AttributeValue, Error, Items};
+    use crate::{from_items, to_attribute_value, AttributeValue, Items};
     use serde_derive::{Deserialize, Serialize};
     use std::collections::HashMap;
 
@@ -157,7 +157,7 @@ mod from_items {
                 (String::from("age"), to_attribute_value(20).unwrap()),
             ]),
             HashMap::from([
-                (String::from("id"), to_attribute_value(42).unwrap()),
+                (String::from("id"), to_attribute_value("two").unwrap()),
                 (String::from("name"), to_attribute_value("John").unwrap()),
                 (
                     String::from("age"),
@@ -166,8 +166,8 @@ mod from_items {
             ]),
         ];
 
-        let err = from_items::<Items, Vec<User>>(items.into()).unwrap_err();
-        assert_eq!(Into::<Error>::into(ErrorImpl::ExpectedSeq), err);
+        let err = from_items::<Items, User>(items.into()).unwrap_err();
+        assert_eq!(String::from("Expected num at '[1].age'"), err.to_string());
     }
 }
 


### PR DESCRIPTION
Example from the `wrong_types` unit test:
```diff
+ Expected num at '[1].age'. Value: S("not a number")
- Expected num
```